### PR TITLE
[DRAFT] Hybrid architecture

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,18 @@
     "license": "GPL-2.0",
     "minimum-stability": "stable",
     "require": {
+        "ezsystems/platform-ui-bundle": "^1.9@dev",
+        "ezsystems/ezpublish-kernel": " ^6.7@dev"
     },
     "require-dev": {
+        "phpspec/phpspec": "^3.2",
+        "memio/spec-gen": "^0.6"
     },
     "autoload": {
+        "psr-4": {
+            "EzSystems\\HybridPlatformUiBundle\\": "src/bundle",
+            "EzSystems\\HybridPlatformUi\\": "src/lib",
+            "specs\\EzSystems\\HybridPlatformUi\\": "specs"
+        }
     }
 }

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,0 +1,13 @@
+extensions:
+    Memio\SpecGen\MemioSpecGenExtension: ~
+
+suites:
+    hybrid_platform_ui:
+        namespace: EzSystems\HybridPlatformUiBundle
+        psr4_prefix: EzSystems\HybridPlatformUiBundle
+        src_path: .
+
+    hybrid_platform_ui_bundle:
+        namespace: EzSystems\HybridPlatformUiBundle
+        psr4_prefix: EzSystems\HybridPlatformUiBundle
+        src_path: .

--- a/spec/Hybrid/AdminRequestMatcherSpec.php
+++ b/spec/Hybrid/AdminRequestMatcherSpec.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace spec\EzSystems\PlatformUIBundle\Hybrid;
+
+use EzSystems\PlatformUIBundle\Hybrid\AdminRequestMatcher;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * @method bool matches(Request $request)
+ */
+class AdminRequestMatcherSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AdminRequestMatcher::class);
+        $this->shouldHaveType(RequestMatcherInterface::class);
+    }
+
+    function it_matches_requests_to_the_admin_siteaccess(
+        Request $request
+    ) {
+        $request->getRequestUri()->willReturn('/admin/foo');
+        $this->matches($request)->shouldEqual(true);
+    }
+}

--- a/spec/Hybrid/DependencyInjection/AdminSiteAccessConfigurationFilterSpec.php
+++ b/spec/Hybrid/DependencyInjection/AdminSiteAccessConfigurationFilterSpec.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace spec\EzSystems\PlatformUIBundle\Hybrid\DependencyInjection;
+
+use eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessConfigurationFilter;
+use EzSystems\PlatformUIBundle\Hybrid\DependencyInjection\AdminSiteAccessConfigurationFilter;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class AdminSiteAccessConfigurationFilterSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AdminSiteAccessConfigurationFilter::class);
+        $this->shouldHaveType(SiteAccessConfigurationFilter::class);
+    }
+
+    function it_creates_an_admin_siteaccess_if_there_is_only_one_group()
+    {
+        $configuration = [
+            'list' => ['site'],
+            'groups' => ['site_group' => ['site']],
+        ];
+        $this->filter($configuration)->shouldBe(
+            [
+                'list' => ['site', 'admin'],
+                'groups' => ['site_group' => ['site', 'admin'], 'admin_group' => ['admin']],
+            ]
+        );
+    }
+
+    function it_creates_an_admin_siteaccess_per_group_if_there_are_several_groups()
+    {
+        $configuration = [
+            'list' => ['bluegill', 'rocky'],
+            'groups' => [
+                'murloc_group' => ['bluegill'],
+                'troll_group' => ['rocky'],
+            ],
+        ];
+        $this->filter($configuration)->shouldBe(
+            $configuration = [
+                'list' => ['bluegill', 'rocky', 'murloc_admin', 'troll_admin'],
+                'groups' => [
+                    'murloc_group' => ['bluegill', 'murloc_admin'],
+                    'troll_group' => ['rocky', 'troll_admin'],
+                    'admin_group' => ['murloc_admin', 'troll_admin'],
+                ],
+            ]
+        );
+
+        $this->filter($configuration)->shouldDefineSiteAccessInGroup('troll_admin', 'troll_group');
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'defineSiteAccessInGroup' => function (array $configuration, $expectedSiteAccess, $group) {
+                return
+                    in_array($expectedSiteAccess, $configuration['list']) &&
+                    isset($configuration['groups'][$group]) &&
+                    in_array($expectedSiteAccess, $configuration['groups'][$group]);
+            }
+        ];
+    }
+}

--- a/spec/Hybrid/DependencyInjection/Compiler/AdminSiteaccessPassSpec.php
+++ b/spec/Hybrid/DependencyInjection/Compiler/AdminSiteaccessPassSpec.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace spec\EzSystems\PlatformUIBundle\Hybrid\DependencyInjection\Compiler;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use EzSystems\PlatformUIBundle\Hybrid\DependencyInjection\Compiler\AdminSiteaccessPass;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class AdminSiteaccessPassSpec extends ObjectBehavior
+{
+    function let(
+        ContainerBuilder $containerBuilder
+    ) {
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AdminSiteaccessPass::class);
+        $this->shouldHaveType(CompilerPassInterface::class);
+    }
+
+    function it_creates_a_unique_admin_siteaccess_when_there_is_one_repository_and_one_root_location(
+        ContainerBuilder $containerBuilder
+    ) {
+        $containerBuilder->getParameter('ezpublish.siteaccess.groups')->willReturn(['site_group' => ['site']]);
+        $containerBuilder->getParameter('ezpublish.siteaccess.list')->willReturn(['site']);
+
+        $containerBuilder->setParameter(
+            'ezpublish.siteaccess.list',
+            Argument::containing('admin')
+        )->shouldBeCalled();
+
+        $containerBuilder->setParameter(
+            'ezpublish.siteaccess.groups',
+            Argument::that(function ($parameter) {
+                return isset($parameter['site_group']) && in_array('admin', $parameter['site_group']);
+            })
+        )->shouldBeCalled();
+
+        $this->process($containerBuilder);
+    }
+}

--- a/spec/Hybrid/EventSubscriber/AppRendererSpec.php
+++ b/spec/Hybrid/EventSubscriber/AppRendererSpec.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace spec\EzSystems\PlatformUIBundle\Hybrid\EventSubscriber;
+
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\PlatformUIBundle\Hybrid\EventSubscriber\AppRendererSubscriber;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Templating\EngineInterface;
+
+/**
+ * @method array getSubscribedEvents()
+ * @method renderApp()
+ */
+class AppRendererSpec extends ObjectBehavior
+{
+    function let(
+        EngineInterface $templateEngine,
+        FilterResponseEvent $event,
+        KernelInterface $kernel,
+        Request $request,
+        Response $response,
+        ParameterBag $requestAttributes,
+        RequestMatcherInterface $adminRequestMatcher
+    ) {
+        $adminRequestMatcher->matches(Argument::type(Request::class))->willReturn(true);
+        $request->attributes = $requestAttributes;
+        $request->duplicate(Argument::cetera())->willReturn(new Request());
+
+        $event->getRequest()->willReturn($request);
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+        $event->getResponse()->willReturn($response);
+
+        $this->beConstructedWith($templateEngine, $kernel, $adminRequestMatcher);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AppRendererSubscriber::class);
+        $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    function it_subscribes_to_the_response_KernelEvent()
+    {
+        $this->getSubscribedEvents()->shouldBeArray();
+        $this->getSubscribedEvents()->shouldSubscribeToEvent(KernelEvents::RESPONSE);
+    }
+
+    function it_ignores_sub_requests(
+        FilterResponseEvent $event
+    ) {
+        $event->getRequestType()->willReturn(HttpKernelInterface::SUB_REQUEST);
+        $event->getRequest()->shouldNotBeCalled();
+        $this->renderApp($event);
+    }
+
+    function it_ignores_requests_without_a_view_attribute(
+        FilterResponseEvent $event,
+        ParameterBag $requestAttributes
+    ) {
+        $requestAttributes->get('view')->willReturn(false);
+        $event->setResponse(Argument::any())->shouldNotBeCalled();
+
+        $this->renderApp($event);
+    }
+
+    function it_ignores_requests_without_a_view_attribute_of_an_unknown_type(
+        FilterResponseEvent $event,
+        ParameterBag $requestAttributes
+    ) {
+        $requestAttributes->get('view')->willReturn(new \stdClass());
+        $event->setResponse(Argument::any())->shouldNotBeCalled();
+
+        $this->renderApp($event);
+    }
+
+    function it_renders_the_app(
+        View $view,
+        EngineInterface $templateEngine,
+        FilterResponseEvent $event,
+        ParameterBag $requestAttributes,
+        Request $request,
+        KernelInterface $kernel
+    ) {
+        $requestAttributes->get('view')->willReturn($view);
+        $kernel->handle(Argument::cetera())->willReturn(new Response());
+        $templateEngine->render(Argument::cetera())->willReturn('the app');
+        $event->setResponse(Argument::type(Response::class))->shouldBeCalled();
+
+        $this->renderApp($event);
+
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'subscribeToEvent' => function (array $subscribedEvents, $event) {
+                return isset($subscribedEvents[$event])
+                    && is_array($subscribedEvents[$event])
+                    && count($subscribedEvents[$event]) === 1;
+            },
+            'havePriorityHigherThan' => function (array $subscribedEvents, $priority) {
+                $event = $subscribedEvents[KernelEvents::VIEW][0];
+                return isset($event[1]) && $event[1] > $priority;
+            },
+            'havePriorityLowerThan' => function (array $subscribedEvents, $priority) {
+                $event = $subscribedEvents[KernelEvents::VIEW][0];
+                return isset($event[1]) && $event[1] < $priority;
+            }
+        ];
+    }
+}

--- a/spec/Hybrid/EventSubscriber/ComponentRendererSpec.php
+++ b/spec/Hybrid/EventSubscriber/ComponentRendererSpec.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace spec\EzSystems\PlatformUIBundle\Hybrid\EventSubscriber;
+
+use EzSystems\PlatformUIBundle\Components\Component;
+use EzSystems\PlatformUIBundle\Hybrid\EventSubscriber\ComponentRendererSubscriber;
+use PhpParser\Node\Arg;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ComponentRendererSpec extends ObjectBehavior
+{
+    function let(
+        Component $component,
+        GetResponseForControllerResultEvent $event,
+        Request $request,
+        RequestMatcherInterface $ajaxUpdateRequestMatcher
+    ) {
+        $this->beConstructedWith($ajaxUpdateRequestMatcher);
+        $event->getRequest()->willReturn($request);
+        $event->getControllerResult()->willReturn($component);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ComponentRendererSubscriber::class);
+        $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    function it_subscribes_to_the_view_KernelEvent()
+    {
+        $this->getSubscribedEvents()->shouldBeArray();
+        $this->getSubscribedEvents()->shouldSubscribeToEvent(KernelEvents::VIEW);
+    }
+
+    function it_ignores_requests_without_a_component_controller_result(
+        GetResponseForControllerResultEvent $event
+    ) {
+        $event->getControllerResult()->willReturn(false);
+        $event->setControllerResult(Argument::any())->shouldNotBeCalled();
+        $this->renderComponent($event);
+    }
+
+    function it_renders_to_a_JsonResponse_if_the_request_is_an_ajax_update(
+        Component $component,
+        GetResponseForControllerResultEvent $event,
+        RequestMatcherInterface $ajaxUpdateRequestMatcher
+    ) {
+        $ajaxUpdateRequestMatcher->matches(Argument::any())->willReturn(true);
+        $component->jsonSerialize()->willReturn(['jsonSerialized', 'array']);
+        $event->setResponse(Argument::type(JsonResponse::class), Argument::cetera())->shouldBeCalled();
+
+        $this->renderComponent($event);
+    }
+
+    function it_renders_to_a_standard_Response_if_the_request_is_not_an_ajax_update(
+        GetResponseForControllerResultEvent $event,
+        Component $component,
+        RequestMatcherInterface $ajaxUpdateRequestMatcher
+    ) {
+        $ajaxUpdateRequestMatcher->matches(Argument::any())->willReturn(false);
+        $component->__toString()->willReturn('The component HTML rendering');
+        $event->setResponse(Argument::type(Response::class), Argument::cetera())->shouldBeCalled();
+
+        $this->renderComponent($event);
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'subscribeToEvent' => function (array $subscribedEvents, $event) {
+                return isset($subscribedEvents[$event])
+                    && is_array($subscribedEvents[$event])
+                    && count($subscribedEvents[$event]) === 1;
+            },
+        ];
+    }
+}

--- a/spec/Hybrid/EventSubscriber/ComponentViewMapperSpec.php
+++ b/spec/Hybrid/EventSubscriber/ComponentViewMapperSpec.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace spec\EzSystems\PlatformUIBundle\Hybrid\EventSubscriber;
+
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\PlatformUIBundle\Components;
+use EzSystems\PlatformUIBundle\Hybrid\EventSubscriber\ComponentViewMapper;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Twig_Environment;
+
+/**
+ * @method array getSubscribedEvents()
+ * @method mapViewToComponent(GetResponseForControllerResultEvent $event)
+ */
+class ComponentViewMapperSpec extends ObjectBehavior
+{
+    function let(
+        GetResponseForControllerResultEvent $event,
+        Request $request,
+        Twig_Environment $twig
+    ) {
+        $this->beConstructedWith($twig);
+        $event->getRequest()->willReturn($request);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ComponentViewMapper::class);
+        $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    function it_subscribes_to_the_view_KernelEvent()
+    {
+        $this->getSubscribedEvents()->shouldBeArray();
+        $this->getSubscribedEvents()->shouldSubscribeToEvent(KernelEvents::VIEW);
+    }
+
+    function it_has_a_higher_priority_than_the_MVC_view_renderer()
+    {
+        $this->getSubscribedEvents()->shouldHavePriorityHigherThan(0);
+    }
+
+    function it_does_not_map_requests_without_a_view_as_controller_result(
+        GetResponseForControllerResultEvent $event,
+        View $view
+    ) {
+        $this->mapViewToComponent($event);
+    }
+
+    function it_does_not_map_non_admin_ui_requests(
+        GetResponseForControllerResultEvent $event,
+        Request $request
+    ) {
+        $request->getRequestUri()->willReturn('/foo/bar');
+        $event->getControllerResult()->shouldNotBeCalled();
+
+        $this->mapViewToComponent($event);
+    }
+
+    function it_maps_controller_results_that_are_views_to_the_MainContent_component(
+        GetResponseForControllerResultEvent $event,
+        Request $request,
+        View $view
+    ) {
+        $request->getRequestUri()->willReturn('/admin/foo');
+        $event->getControllerResult()->willReturn($view);
+
+        $event->setControllerResult(Argument::type(Components\MainContent::class))->shouldBeCalled();
+
+        $this->mapViewToComponent($event);
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'subscribeToEvent' => function (array $subscribedEvents, $event) {
+                return isset($subscribedEvents[$event])
+                    && is_array($subscribedEvents[$event])
+                    && count($subscribedEvents[$event]) === 1;
+            },
+            'havePriorityHigherThan' => function (array $subscribedEvents, $priority) {
+                $event = $subscribedEvents[KernelEvents::VIEW][0];
+                return isset($event[1]) && $event[1] > $priority;
+            }
+        ];
+    }
+}

--- a/spec/Hybrid/EventSubscriber/PjaxResponseSubscriberSpec.php
+++ b/spec/Hybrid/EventSubscriber/PjaxResponseSubscriberSpec.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace spec\EzSystems\PlatformUIBundle\Hybrid\EventSubscriber;
+
+use EzSystems\PlatformUIBundle\Hybrid\EventSubscriber\AppRendererSubscriber;
+use EzSystems\PlatformUIBundle\Hybrid\EventSubscriber\PjaxResponseSubscriber;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @method array getSubscribedEvents()
+ * @method mapPjaxResponseToHybridResponse(FilterResponseEvent $event)
+ */
+class PjaxResponseSubscriberSpec extends ObjectBehavior
+{
+    function let(
+        FilterResponseEvent $event,
+        Request $request,
+        Response $response,
+        RequestMatcherInterface $adminRequestMatcher,
+        RequestMatcherInterface $pjaxRequestMatcher
+    ) {
+        $adminRequestMatcher->matches(Argument::type(Request::class))->willReturn(true);
+        $pjaxRequestMatcher->matches(Argument::type(Request::class))->willReturn(true);
+        $event->getRequest()->willReturn($request);
+        $event->getResponse()->willReturn($response);
+
+        $this->beConstructedWith($adminRequestMatcher, $pjaxRequestMatcher);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PjaxResponseSubscriber::class);
+        $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    function it_subscribes_to_the_response_KernelEvent()
+    {
+        $this->getSubscribedEvents()->shouldBeArray();
+        $this->getSubscribedEvents()->shouldSubscribeToEvent(KernelEvents::RESPONSE);
+    }
+
+    function it_has_a_higher_priority_than_the_AppRenderer() {
+        $this->getSubscribedEvents()->shouldHaveHigherPriorityThan(AppRendererSubscriber::class);
+    }
+
+    function it_skips_non_admin_requests(
+        FilterResponseEvent $event,
+        Request $request,
+        RequestMatcherInterface $adminRequestMatcher
+    ) {
+        $adminRequestMatcher->matches($request)->willReturn(false);
+        $this->mapPjaxResponseToHybridResponse($event);
+        $event->getResponse()->shouldNotHaveBeenCalled();
+    }
+
+    function it_skips_non_pjax_requests(
+        FilterResponseEvent $event,
+        Request $request,
+        RequestMatcherInterface $pjaxRequestMatcher
+    ) {
+        $pjaxRequestMatcher->matches($request)->willReturn(false);
+        $this->mapPjaxResponseToHybridResponse($event);
+        $event->getResponse()->shouldNotHaveBeenCalled();
+    }
+
+    function it_builds_a_HybridUiView_from_the_pjax_response_content(
+        FilterResponseEvent $event
+    ) {
+        $this->mapPjaxResponseTohybridResponse($event);
+
+        $event->setResponse(Argument::type(Response::class))->shouldHaveBeenCalled();
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'subscribeToEvent' => function (array $subscribedEvents, $event) {
+                return isset($subscribedEvents[$event])
+                    && is_array($subscribedEvents[$event]);
+            },
+            'haveHigherPriorityThan' => function (array $subscribedEvents, $otherSubscriberClass) {
+                return $subscribedEvents[KernelEvents::RESPONSE][1] > $this->getFirstSubscriberPriority($otherSubscriberClass);
+            },
+            'haveLowerPriorityThan' => function (array $subscribedEvents, $otherSubscriberClass) {
+                return $subscribedEvents[KernelEvents::RESPONSE][1] < $this->getFirstSubscriberPriority($otherSubscriberClass);
+            }
+        ];
+    }
+
+    /**
+     * Returns the priority of the first subscriber of KernelEvents::RESPONSE.
+     *
+     * @param string $subscriberClass
+     *
+     * @return int
+     */
+    private function getFirstSubscriberPriority($subscriberClass)
+    {
+        if (!in_array(EventSubscriberInterface::class, class_implements($subscriberClass))) {
+            throw new \Exception("Comparison class isn't an EventSubscriber");
+        }
+        $subscribedEvents = $subscriberClass::getSubscribedEvents();
+        if (!isset($subscribedEvents[KernelEvents::RESPONSE])) {
+            throw new \Exception("Comparison class doesn't subscribe to KernelEvents::RESPONSE");
+        }
+        $event = $subscribedEvents[KernelEvents::RESPONSE][0];
+
+        return isset($event[1]) ? $event[1] : 0;
+    }
+}

--- a/spec/Hybrid/EventSubscriber/ViewToMainComponentMapperSpec.php
+++ b/spec/Hybrid/EventSubscriber/ViewToMainComponentMapperSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace spec\EzSystems\PlatformUIBundle\Hybrid\EventSubscriber;
+
+use EzSystems\PlatformUIBundle\Hybrid\EventSubscriber\ViewToMainComponentMapper;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Templating\EngineInterface;
+
+class ViewToMainComponentMapperSpec extends ObjectBehavior
+{
+    function let(
+        EngineInterface $templating,
+        RequestMatcherInterface $adminRequestMatcher)
+    {
+        $adminRequestMatcher->matches(Argument::type(Request::class))->willReturn(true);
+        $this->beConstructedWith($templating, $adminRequestMatcher);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ViewToMainComponentMapper::class);
+        $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    function it_subscribes_to_the_view_KernelEvent()
+    {
+        $this->getSubscribedEvents()->shouldBeArray();
+        $this->getSubscribedEvents()->shouldSubscribeToEvent(KernelEvents::VIEW);
+    }
+
+    function it_has_higher_priority_than_the_core_view_renderer_listener()
+    {
+        $this->getSubscribedEvents()->shouldHaveHigherPriorityThan(0);
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'subscribeToEvent' => function (array $subscribedEvents, $event) {
+                return isset($subscribedEvents[$event])
+                    && is_array($subscribedEvents[$event])
+                    && count($subscribedEvents[$event]) === 1;
+            },
+            'havePriorityHigherThan' => function (array $subscribedEvents, $priority) {
+                $event = $subscribedEvents[KernelEvents::VIEW][0];
+                return isset($event[1]) && $event[1] > $priority;
+            }
+        ];
+    }
+}

--- a/spec/Hybrid/Http/AjaxUpdateRequestMatcherSpec.php
+++ b/spec/Hybrid/Http/AjaxUpdateRequestMatcherSpec.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace spec\EzSystems\PlatformUIBundle\Hybrid\Http;
+
+use EzSystems\PlatformUIBundle\Hybrid\Http\AjaxUpdateRequestMatcher;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+class AjaxUpdateRequestMatcherSpec extends ObjectBehavior
+{
+    function let(
+        HeaderBag $headerBag,
+        Request $request
+    ) {
+        $request->headers = $headerBag;
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AjaxUpdateRequestMatcher::class);
+        $this->shouldHaveType(RequestMatcherInterface::class);
+    }
+
+    function it_matches_requests_with_the_x_ajax_update_header(
+        HeaderBag $headerBag,
+        Request $request
+    ) {
+        $headerBag->get('x-ajax-update', 0)->willReturn(1);
+        $this->matches($request)->shouldBe(true);
+    }
+
+    function it_does_not_match_requests_with_the_x_ajax_update_header(
+        HeaderBag $headerBag,
+        Request $request
+    ) {
+        $headerBag->get('x-ajax-update', 0)->willReturn(0);
+        $this->matches($request)->shouldBe(false);
+    }
+}

--- a/spec/Hybrid/Mapper/PjaxResponseHybridViewMapperSpec.php
+++ b/spec/Hybrid/Mapper/PjaxResponseHybridViewMapperSpec.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace spec\EzSystems\PlatformUIBundle\Hybrid\Mapper;
+
+use EzSystems\PlatformUIBundle\Hybrid\Mapper\PjaxResponseHybridViewMapper;
+use EzSystems\PlatformUIBundle\Hybrid\View\PjaxViewToDelete;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @method Response MapResponse(Response $response)
+ */
+class PjaxResponseHybridViewMapperSpec extends ObjectBehavior
+{
+    function let(Response $response)
+    {
+        $response->getContent()->willReturn(
+            file_get_contents(__DIR__ . '/_fixtures/pjax_response.html')
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PjaxResponseHybridViewMapper::class);
+    }
+
+    function it_maps_to_a_PjaxView(Response $response)
+    {
+        $this->mapResponse($response)->shouldHaveType(PjaxViewToDelete::class);
+    }
+
+    function it_parses_the_title(Response $response)
+    {
+        $this->mapResponse($response)->shouldHaveTitle('Response title');
+    }
+
+    function it_parses_the_content(Response $response)
+    {
+        $this->mapResponse($response)->shouldHaveContent('Server side content');
+    }
+
+    function getMatchers()
+    {
+        return [
+            'haveTitle' => function (PjaxViewToDelete $view, $expectedTitle) {
+                return $view->getTitle() == $expectedTitle;
+            },
+            'haveContent' => function (PjaxViewToDelete $view, $expectedContent) {
+                return $view->getContent() == $expectedContent;
+            },
+        ];
+    }
+}

--- a/spec/Hybrid/Mapper/_fixtures/pjax_response.html
+++ b/spec/Hybrid/Mapper/_fixtures/pjax_response.html
@@ -1,0 +1,11 @@
+<div data-name="title">Response title</div>
+
+<div data-name="html">
+    <header class="ez-page-header">
+        <nav class="ez-breadcrumbs">breadcrumb</nav>
+        <h1 class="ez-page-header-name" data-icon="&#xe91f;">Header</h1>
+    </header>
+    <section class="extra-class ez-serverside-content">Server side content</section>
+</div>
+
+<ul data-name="notification">Notifications </ul>

--- a/src/bundle/Controller/ProtoBDController.php
+++ b/src/bundle/Controller/ProtoBDController.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * File containing the DashboardController class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\HybridPlatformUiBundle\Controller;
+
+use EzSystems\HybridPlatformUi\Components\MainContent;
+use EzSystems\PlatformUIBundle\Controller\Controller;
+
+class ProtoBDController extends Controller
+{
+    public function dashboardAction()
+    {
+        // @todo Fix this
+        $content = new MainContent($this->container->get('templating'));
+        $content->setTemplate('EzSystemsHybridPlatformUiBundle::dashboard.html.twig');
+
+        return $content;
+    }
+}

--- a/src/bundle/Controller/ProtoController.php
+++ b/src/bundle/Controller/ProtoController.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * File containing the DashboardController class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\HybridPlatformUiBundle\Controller;
+
+use EzSystems\HybridPlatformUi\Components\App;
+use EzSystems\PlatformUIBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\RouterInterface;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+class ProtoController extends Controller
+{
+    /**
+     * @var \EzSystems\HybridPlatformUi\Components\App
+     */
+    protected $app;
+
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface
+     */
+    private $router;
+
+    public function __construct(App $app, RouterInterface $router)
+    {
+        $this->app = $app;
+        $this->router = $router;
+    }
+
+    public function dashboardAction(Request $request)
+    {
+        $appConfig = $request->attributes->get('appConfig');
+        $appConfig['title'] = 'Dashboard';
+        $this->app->setConfig($appConfig);
+
+        if ($request->headers->has('x-ajax-update')) {
+            return JsonResponse::create($this->app);
+        }
+
+        return $this->render('eZPlatformUIBundle:PlatformUI:proto.html.twig', ['platformUIApp' => $this->app]);
+    }
+
+    public function locationViewAction(Request $request, Location $location)
+    {
+        $appConfig = $request->attributes->get('appConfig');
+        $appConfig['title'] = $location->contentInfo->name;
+        $appConfig['mainContent']['parameters']['location'] = $location;
+        $this->app->setConfig($appConfig);
+
+        if ($request->headers->has('x-ajax-update')) {
+            return JsonResponse::create($this->app);
+        }
+
+        return $this->render('eZPlatformUIBundle:PlatformUI:proto.html.twig', ['platformUIApp' => $this->app]);
+    }
+
+    public function draftCreateAction(Request $request, Content $content)
+    {
+        $controller = $this->get('ez_content_edit');
+        $controller->setPagelayout('EzPublishCoreBundle::viewbase_layout.html.twig');
+        $response = $controller->createContentDraftAction($content->id, null, null, null, $request);
+        if ($response instanceof RedirectResponse) {
+            $parameters = $this->router->match($response->getTargetUrl());
+            unset($parameters['_controller'], $parameters['_route']);
+            $response->setTargetUrl(
+                $this->router->generate('proto_content_edit', $parameters)
+            );
+            return $response;
+        }
+        $appConfig = $request->attributes->get('appConfig');
+        $appConfig['title'] = '';
+        $appConfig['mainContent']['result'] = $response->getContent();
+        $this->app->setConfig($appConfig);
+
+        if ($request->headers->has('x-ajax-update')) {
+            return JsonResponse::create($this->app);
+        }
+
+        return $this->render('eZPlatformUIBundle:PlatformUI:proto.html.twig', ['platformUIApp' => $this->app]);
+    }
+
+    public function editContentDraftAction(Request $request, Content $content, $versionNo, $language)
+    {
+        // @todo Make content edit a view
+        $controller = $this->get('ez_content_edit');
+        $controller->setPagelayout('EzPublishCoreBundle::viewbase_layout.html.twig');
+        $response = $controller->editContentDraftAction($content->id, $versionNo, $request, $language);
+        if ($response instanceof RedirectResponse) {
+            $response->setTargetUrl(
+                $this->router->generate(
+                    'proto_viewLocation',
+                    ['locationId' => $content->contentInfo->mainLocationId]
+                )
+            );
+            return $response;
+        }
+        $appConfig = $request->attributes->get('appConfig');
+        $appConfig['title'] = '';
+        $appConfig['mainContent']['result'] = $response->getContent();
+        $this->app->setConfig($appConfig);
+
+        if ($request->headers->has('x-ajax-update')) {
+            return JsonResponse::create($this->app);
+        }
+
+        return $this->render('eZPlatformUIBundle:PlatformUI:proto.html.twig', ['platformUIApp' => $this->app]);
+    }
+}

--- a/src/bundle/DependencyInjection/Compiler/NavigationHubPass.php
+++ b/src/bundle/DependencyInjection/Compiler/NavigationHubPass.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUiBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class NavigationHubPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('ezsystems.platformui.component.navigationhub')) {
+            return;
+        }
+
+        $this->processNavigationHubTag($container, 'ezplatform.ui.zone', 2);
+        $this->processNavigationHubTag($container, 'ezplatform.ui.link', 3);
+    }
+
+    private function processNavigationHubTag(ContainerBuilder $container, $tag, $index)
+    {
+        $items = [];
+        $services = $container->findTaggedServiceIds($tag);
+        foreach (array_keys($services) as $serviceId) {
+            $items[] = new Reference($serviceId);
+        }
+
+        $container
+            ->getDefinition('ezsystems.platformui.component.navigationhub')
+            ->replaceArgument($index, $items);
+    }
+}

--- a/src/bundle/DependencyInjection/Compiler/ToolbarsPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ToolbarsPass.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUiBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use LogicException;
+
+class ToolbarsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('ezsystems.platformui.component.app')) {
+            return;
+        }
+
+        $toolbars = [];
+        $toolbarsItems = [];
+
+        foreach ($container->findTaggedServiceIds('ezplatform.ui.toolbar_item') as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                if (!isset($tag['toolbar'])) {
+                    throw new LogicException("Missing mandatory tag attribute 'toolbar' for service " . $serviceId);
+                }
+                $toolbarsItems[$tag['toolbar']][] = new Reference($serviceId);
+            }
+        }
+
+        foreach ($container->findTaggedServiceIds('ezplatform.ui.toolbar') as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                if (!isset($tag['alias'])) {
+                    throw new LogicException("Missing mandatory tag attribute 'toolbar' for service ". $serviceId);
+                }
+
+                $toolbarDefinition = $container->getDefinition($serviceId);
+                $toolbarDefinition->replaceArgument(0, $tag['alias']);
+
+                if (isset($toolbarsItems[$tag['alias']])) {
+                    $toolbarDefinition->replaceArgument(1, $toolbarsItems[$tag['alias']]);
+                    unset($toolbarsItems[$tag['alias']]);
+                }
+
+                $toolbars[] = new Reference($serviceId);
+            }
+        }
+
+        if (count($toolbarsItems) > 0) {
+            $message =
+                "Services tagged as ezplatform.ui.toolbar_item were found that aren't attached to any toolbar: " .
+                implode(', ', array_keys($toolbarsItems));
+
+            throw new LogicException($message);
+        }
+
+        $container
+            ->getDefinition('ezsystems.platformui.component.app')
+            ->replaceArgument(3, $toolbars);
+    }
+}

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace EzSystems\HybridPlatformUiBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('ez_systems_platform_hybrid_ui');
+
+        return $treeBuilder;
+    }
+}

--- a/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
+++ b/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace EzSystems\HybridPlatformUiBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration.
+ *
+ * @link http://symfony.com/doc/current/cookbook/bundles/extension.html
+ */
+class EzSystemsHybridPlatformUiExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+        $loader->load('navigationhub.yml');
+        $loader->load('toolbars.yml');
+        $loader->load('components.yml');
+    }
+}

--- a/src/bundle/EzSystemsHybridPlatformUiBundle.php
+++ b/src/bundle/EzSystemsHybridPlatformUiBundle.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace EzSystems\HybridPlatformUiBundle;
+
+use EzSystems\HybridPlatformUi\Platform\AdminSiteAccessConfigurationFilter;
+use EzSystems\HybridPlatformUiBundle\DependencyInjection\Compiler\NavigationHubPass;
+use EzSystems\HybridPlatformUiBundle\DependencyInjection\Compiler\ToolbarsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class EzSystemsHybridPlatformUiBundle extends Bundle
+{
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new NavigationHubPass());
+        $container->addCompilerPass(new ToolbarsPass());
+
+        $eZExtension = $container->getExtension('ezpublish');
+        $eZExtension->addSiteAccessConfigurationFilter(
+            new AdminSiteAccessConfigurationFilter()
+        );
+    }
+}

--- a/src/bundle/Resources/config/components.yml
+++ b/src/bundle/Resources/config/components.yml
@@ -1,0 +1,24 @@
+services:
+    ezsystems.platformui.component.app:
+        class: EzSystems\HybridPlatformUi\Components\App
+        arguments:
+            - "@templating"
+            - "@ezsystems.platformui.component.maincontent"
+            - "@ezsystems.platformui.component.navigationhub"
+            # @todo tag those services so that it's possible to add
+            # new toolbars
+            - ["@ezsystems.platformui.component.discoverybar"]
+
+    ezsystems.platformui.component.maincontent:
+        class: EzSystems\HybridPlatformUi\Components\MainContent
+        arguments:
+            - "@templating"
+        shared: false
+
+    ezsystems.platformui.component.navigationhub:
+        class: EzSystems\HybridPlatformUi\Components\NavigationHub
+        arguments:
+            - "@templating"
+            - "@request_stack"
+            - []
+            - []

--- a/src/bundle/Resources/config/navigationhub.yml
+++ b/src/bundle/Resources/config/navigationhub.yml
@@ -1,0 +1,127 @@
+parameters:
+    ezsystems.platformui.navigationhub.zone.class: EzSystems\HybridPlatformUi\NavigationHub\Zone
+    ezsystems.platformui.navigationhub.link.route.class: EzSystems\HybridPlatformUi\NavigationHub\Link\Route
+    ezsystems.platformui.navigationhub.link.subtree.class: EzSystems\HybridPlatformUi\NavigationHub\Link\Subtree
+
+services:
+    ezsystems.platformui.navigationhub.zones.content:
+        class: "%ezsystems.platformui.navigationhub.zone.class%"
+        arguments:
+            - "Content"
+            - "content"
+        tags:
+            - {name: ezplatform.ui.zone}
+
+    ezsystems.platformui.navigationhub.zones.page:
+        class: "%ezsystems.platformui.navigationhub.zone.class%"
+        arguments:
+            - "Page"
+            - "page"
+        tags:
+            - {name: ezplatform.ui.zone}
+
+    ezsystems.platformui.navigationhub.zones.performances:
+        class: "%ezsystems.platformui.navigationhub.zone.class%"
+        arguments:
+            - "Performances"
+            - "performances"
+        tags:
+            - {name: ezplatform.ui.zone}
+
+    ezsystems.platformui.navigationhub.zones.admin:
+        class: "%ezsystems.platformui.navigationhub.zone.class%"
+        arguments:
+            - "Admin Panel"
+            - "admin"
+        tags:
+            - {name: ezplatform.ui.zone}
+
+    ezsystems.platformui.navigationhub.link.contentstructure:
+        class: "%ezsystems.platformui.navigationhub.link.subtree.class%"
+        arguments:
+            - "@router"
+            # Should be Core content route
+            - "ez_urlalias"
+            - {"locationId": 2}
+            - "Content structure"
+            - "content"
+        tags:
+            - {name: ezplatform.ui.link}
+
+    ezsystems.platformui.navigationhub.link.medialibrary:
+        class: "%ezsystems.platformui.navigationhub.link.subtree.class%"
+        arguments:
+            - "@router"
+            - "ez_urlalias"
+            - {"locationId": 2}
+            - "Media Library"
+            - "content"
+        tags:
+            - {name: ezplatform.ui.link}
+
+    ezsystems.platformui.navigationhub.link.users:
+        class: "%ezsystems.platformui.navigationhub.link.subtree.class%"
+        arguments:
+            - "@router"
+            - "ez_urlalias"
+            - {"locationId": 2}
+            - "Users"
+            - "admin"
+        tags:
+            - {name: ezplatform.ui.link}
+
+    ezsystems.platformui.navigationhub.link.admin.section:
+        class: "%ezsystems.platformui.navigationhub.link.route.class%"
+        arguments:
+            - "@router"
+            - "admin_sectionlist"
+            - {}
+            - "Sections"
+            - "admin"
+        tags:
+            - {name: ezplatform.ui.link}
+
+    ezsystems.platformui.navigationhub.link.admin.languages:
+        class: "%ezsystems.platformui.navigationhub.link.route.class%"
+        arguments:
+            - "@router"
+            - "admin_languagelist"
+            - {}
+            - "Languages"
+            - "admin"
+        tags:
+            - {name: ezplatform.ui.link}
+
+    ezsystems.platformui.navigationhub.link.admin.content_types:
+        class: "%ezsystems.platformui.navigationhub.link.route.class%"
+        arguments:
+            - "@router"
+            - "admin_contenttypeGroupList"
+            - {}
+            - "Content types"
+            - "admin"
+        tags:
+            - {name: ezplatform.ui.link}
+
+    ezsystems.platformui.navigationhub.link.admin.roles:
+        class: "%ezsystems.platformui.navigationhub.link.route.class%"
+        arguments:
+            - "@router"
+            - "admin_roleList"
+            - {}
+            - "Roles"
+            - "admin"
+        tags:
+            - {name: ezplatform.ui.link}
+
+    ezsystems.platformui.navigationhub.link.admin.system_info:
+        class: "%ezsystems.platformui.navigationhub.link.route.class%"
+        arguments:
+            - "@router"
+            - "admin_systeminfo"
+            - {}
+            - "System info"
+            - "admin"
+        tags:
+            - {name: ezplatform.ui.link}
+

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -1,0 +1,9 @@
+_ez_hybrid_platform_ui_dp:
+    resource: "@EzSystemsHybridPlatformUiBundle/Resources/config/routing_proto.yml"
+    prefix:   /proto
+
+ez_hybrid_platform_ui_dashboard:
+    path: /dashboard
+    defaults:
+        _controller: EzSystemsHybridPlatformUiBundle:ProtoBD:dashboard
+    methods: [GET]

--- a/src/bundle/Resources/config/routing_proto.yml
+++ b/src/bundle/Resources/config/routing_proto.yml
@@ -1,0 +1,52 @@
+proto_dashboard:
+    path: /dashboard
+    defaults:
+        _controller: ezsystems.platformui.controller.proto:dashboardAction
+        appConfig:
+            mainContent:
+                template: 'eZPlatformUIBundle:PlatformUI:dashboard.html.twig'
+                parameters: []
+            toolbars:
+            # by default toolbars are hidden, so the following is not really needed
+            #     discovery: 0
+    methods: [GET]
+
+proto_viewLocation:
+    # could/should we reuse the Location's nice URL, so that to browse we could
+    # have /proto/My-Nice-URL/To/A/Location ?
+    path: /location/view/{locationId}
+    defaults:
+        _controller: ezsystems.platformui.controller.proto:locationViewAction
+        appConfig:
+            toolbars:
+                discovery: 1
+            mainContent:
+                template: 'eZPlatformUIBundle:PlatformUI:locationview.html.twig'
+                parameters: []
+    methods: [GET]
+    requirements:
+        locationId: \d+
+    options:
+        expose: true
+
+proto_draft_create:
+    path: /content/create/draft/{contentId}
+    methods: [GET, POST]
+    defaults:
+        _controller: ezsystems.platformui.controller.proto:draftCreateAction
+        appConfig:
+            toolbars:
+                discovery: 1
+            mainContent:
+                parameters: []
+
+proto_content_edit:
+    path: /content/edit/{contentId}/{versionNo}/{language}
+    methods: [GET, POST]
+    defaults:
+        _controller: ezsystems.platformui.controller.proto:editContentDraftAction
+        appConfig:
+            toolbars:
+                discovery: 0
+            mainContent:
+                parameters: []

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -1,0 +1,83 @@
+parameters:
+    # prototype components
+    ezsystems.platformui.component.app.class: EzSystems\HybridPlatformUi\Components\App
+    ezsystems.platformui.component.maincontent.class: EzSystems\HybridPlatformUi\Components\MainContent
+    ezsystems.platformui.component.navigationhub.class: EzSystems\HybridPlatformUi\Components\NavigationHub
+    ezsystems.platformui.component.toolbar.class: EzSystems\HybridPlatformUi\Components\Toolbar
+    ezsystems.platformui.component.search.class: EzSystems\HybridPlatformUi\Components\Search
+    ezsystems.platformui.component.browse.class: EzSystems\HybridPlatformUi\Components\Browse
+    ezsystems.platformui.component.trash.class: EzSystems\HybridPlatformUi\Components\Trash
+
+services:
+    ezsystems.platformui.controller.proto:
+        class: "%ezsystems.platformui.controller.proto.class%"
+        arguments:
+            - "@ezsystems.platformui.component.app"
+            - "@router"
+        parent: ezsystems.platformui.controller.base
+
+    ezsystems.platformui.controller.webcomponent:
+        class: "%ezsystems.platformui.controller.webcomponent.class%"
+        arguments:
+            - "@ezsystems.platformui.application_config.aggregator"
+        parent: ezsystems.platformui.controller.base
+
+    ezsystems.platformui.hybrid.request_matcher.admin:
+        class: EzSystems\HybridPlatformUi\Http\HardcodedAdminRequestMatcher
+
+    ezsystems.platformui.hybrid.request_matcher.ajax_update:
+        class: EzSystems\HybridPlatformUi\Http\AjaxUpdateRequestMatcher
+
+    ezsystems.platformui.hybrid.event_subscriber.app_renderer:
+        class: EzSystems\HybridPlatformUi\EventSubscriber\AppRendererSubscriber
+        arguments:
+            - "@ezsystems.platformui.component.app"
+            - "@ezsystems.platform_ui.hybrid.app.request_app_response_renderer"
+            - "@ezsystems.platformui.hybrid.request_matcher.admin"
+        tags:
+            - {name: kernel.event_subscriber}
+
+    ezsystems.platformui.hybrid.event_subscriber.pjax_response_subscriber:
+        class: EzSystems\HybridPlatformUi\EventSubscriber\PjaxResponseSubscriber
+        arguments:
+            - "@ezsystems.platformui.component.app"
+            - "@ezsystems.platform_ui.hybrid.app.request_app_response_renderer"
+            - "@ezsystems.platformui.hybrid.mapper.pjax_response_to_main_content"
+            - "@ezsystems.platformui.hybrid.request_matcher.admin"
+            - "@ezsystems.platformui.pjax.request_matcher"
+        tags:
+            - {name: kernel.event_subscriber}
+
+    ezsystems.platformui.hybrid.event_subscriber.component_renderer:
+        class: EzSystems\HybridPlatformUi\EventSubscriber\ComponentRendererSubscriber
+        arguments:
+            - "@ezsystems.platformui.hybrid.request_matcher.admin"
+        tags:
+            - {name: kernel.event_subscriber}
+
+    ezsystems.platformui.hybrid.event_subscriber.core_view:
+        class: EzSystems\HybridPlatformUi\EventSubscriber\CoreViewSubscriber
+        arguments:
+            - "@ezsystems.platformui.hybrid.mapper.core_view_to_main_content"
+            - "@ezsystems.platformui.hybrid.request_matcher.ajax_update"
+        tags:
+            - {name: kernel.event_subscriber}
+
+    ezsystems.platformui.hybrid.mapper.core_view_to_main_content:
+        class: EzSystems\HybridPlatformUi\Mapper\CoreViewMainContentMapper
+        arguments:
+            - "@ezsystems.platformui.component.maincontent"
+
+    ezsystems.platformui.hybrid.mapper.pjax_response_to_main_content:
+        class: EzSystems\HybridPlatformUi\Mapper\PjaxResponseMainContentMapper
+        arguments:
+            - "@ezsystems.platformui.component.maincontent"
+
+#    ezsystems.platformui.hybrid.view.pjax_view_renderer:
+#        class: EzSystems\HybridPlatformUi\View\Renderer\PjaxViewRenderer
+#
+    ezsystems.platform_ui.hybrid.app.request_app_response_renderer:
+        class: EzSystems\HybridPlatformUi\App\RequestAppResponseRenderer
+        arguments:
+            - '@request_stack'
+            - '@ezsystems.platformui.hybrid.request_matcher.ajax_update'

--- a/src/bundle/Resources/config/toolbars.yml
+++ b/src/bundle/Resources/config/toolbars.yml
@@ -1,0 +1,25 @@
+services:
+    ezsystems.platformui.component.discoverybar:
+        class: "%ezsystems.platformui.component.toolbar.class%"
+        arguments:
+            - ~
+            - []
+        tags:
+            - {name: ezplatform.ui.toolbar, alias: "discovery"}
+
+    ezsystems.platformui.component.search:
+        class: "%ezsystems.platformui.component.search.class%"
+        tags:
+            - {name: ezplatform.ui.toolbar_item, toolbar: "discovery"}
+
+    ezsystems.platformui.component.browse:
+        class: "%ezsystems.platformui.component.browse.class%"
+        arguments: [@request_stack, @router]
+        tags:
+            - {name: ezplatform.ui.toolbar_item, toolbar: "discovery"}
+
+    ezsystems.platformui.component.trash:
+        class: "%ezsystems.platformui.component.trash.class%"
+        tags:
+            - {name: ezplatform.ui.toolbar_item, toolbar: "discovery"}
+

--- a/src/bundle/Resources/views/dashboard.html.twig
+++ b/src/bundle/Resources/views/dashboard.html.twig
@@ -1,0 +1,1 @@
+<h1>Dashboard</h1>

--- a/src/bundle/Resources/views/locationview.html.twig
+++ b/src/bundle/Resources/views/locationview.html.twig
@@ -1,0 +1,14 @@
+<h1>{{ location.contentInfo.name }} (Location #{{ location.id }})</h1>
+
+<p>
+<a href="{{ path('proto_draft_create', {contentId: location.contentInfo.id}) }}">Edit this content</a>
+</p>
+
+{# using the REST id Location for now to not have to find a cheap and easy way
+ # to get the REST id for the regular Location id, but at the some point, this will
+ # have to be changed. This involves developping a new view service.
+ # see app.renderView() call in WebComponent/ez-subitem.html.twig
+ #}
+<ez-subitem parent-location-id="{{ '/api/ezp/v2/content/locations/' ~ location.pathString|trim('/') }}">
+    Loading subitems...
+</ez-subitem>

--- a/src/lib/App/AppResponseRenderer.php
+++ b/src/lib/App/AppResponseRenderer.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUi\App;
+
+use EzSystems\HybridPlatformUi\Components\App;
+use Symfony\Component\HttpFoundation\Response;
+
+interface AppResponseRenderer
+{
+    public function render(Response $response, App $app);
+}

--- a/src/lib/App/RequestAppResponseRenderer.php
+++ b/src/lib/App/RequestAppResponseRenderer.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUi\App;
+
+use EzSystems\HybridPlatformUi\Components\App;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequestAppResponseRenderer implements AppResponseRenderer
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestMatcherInterface
+     */
+    private $ajaxUpdateRequestMatcher;
+
+    public function __construct(
+        RequestStack $requestStack,
+        RequestMatcherInterface $ajaxUpdateRequestMatcher
+    ) {
+
+        $this->requestStack = $requestStack;
+        $this->ajaxUpdateRequestMatcher = $ajaxUpdateRequestMatcher;
+    }
+
+    public function render(Response $response, App $app)
+    {
+        $appResponse = $this->ajaxUpdateRequestMatcher->matches($this->requestStack->getMasterRequest())
+            ? new JsonResponse($app)
+            : new Response($app);
+
+        $response
+            ->setContent($appResponse->getContent())
+            ->headers->replace($appResponse->headers->all());
+    }
+}

--- a/src/lib/Components/App.php
+++ b/src/lib/Components/App.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+use Symfony\Component\HttpFoundation\Request;
+use EzSystems\HybridPlatformUi\Components\Component;
+use EzSystems\HybridPlatformUi\Components\NavigationHub;
+use EzSystems\HybridPlatformUi\Components\MainContent;
+
+/**
+ * Could this be BOTH a component and a Subscriber ?
+ * It would be harder to test...
+ * But does it have much that needs to be tested ?
+ * Does it really help ? It would meant that the app subscribes to the MVC layer and
+ * takes care of rendering the result. It may make some sense.
+ */
+class App implements Component
+{
+    const TAG_NAME = 'ez-platformui-app';
+
+    protected $mainContent;
+
+    protected $navigationHub;
+
+    protected $toolbars;
+
+    protected $templating;
+
+    protected $title;
+
+    public function __construct(
+        $templating,
+        MainContent $content,
+        NavigationHub $navigationHub,
+        array $toolbars
+    ) {
+        $this->templating = $templating;
+        $this->mainContent = $content;
+        $this->navigationHub = $navigationHub;
+        $this->toolbars = $toolbars;
+    }
+
+    public function setConfig(array $config)
+    {
+        if (isset($config['title'])) {
+            $this->title = $config['title'];
+        }
+        if (isset($config['toolbars'])) {
+            $this->setToolbarsVisibility($config['toolbars']);
+        }
+
+        if (isset($config['mainContent']) && $config['mainContent'] instanceof Component) {
+            $this->mainContent = $config['mainContent'];
+        } elseif (isset($config['mainContent']['result'])) {
+            $this->mainContent->setResult($config['mainContent']['result']);
+        } elseif (is_array($config['mainContent'])) {
+            $this->mainContent->setTemplate($config['mainContent']['template']);
+            $this->mainContent->setParameters($config['mainContent']['parameters']);
+        }
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    protected function setToolbarsVisibility($config)
+    {
+        foreach ($this->toolbars as $toolbar) {
+            $toolbar->setVisible((bool)$config[$toolbar->getId()]);
+        }
+    }
+
+    public function __toString()
+    {
+        return $this->templating->render(
+            'eZPlatformUIBundle:Components:app.html.twig',
+            [
+                'navigationHub' => $this->navigationHub,
+                'toolbars' => $this->toolbars,
+                'mainContent' => $this->mainContent,
+                'appTagName' => self::TAG_NAME,
+            ]
+        );
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'selector' => self::TAG_NAME,
+            'update' => [
+                'attributes' => [
+                    'title' => $this->title,
+                    'url' => $_SERVER['REQUEST_URI'],
+                ],
+                'children' => array_merge(
+                    $this->toolbars,
+                    [$this->navigationHub, $this->mainContent]
+                ),
+            ]
+        ];
+    }
+}

--- a/src/lib/Components/Browse.php
+++ b/src/lib/Components/Browse.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RouterInterface;
+
+class Browse implements Component
+{
+    protected $router;
+
+    protected $request;
+
+    // passing the router is needed because at the moment the UDW only supports
+    // a REST Location id as the starting Location id, so this id is build there
+    public function __construct(RequestStack $stack, RouterInterface $router)
+    {
+        $this->request = $stack->getMasterRequest();
+        $this->router = $router;
+    }
+
+    protected function getLocationId()
+    {
+        if ($this->request->attributes->get('location')) {
+            return $this->request->attributes->get('location')->id;
+        }
+        return "false";
+    }
+
+    protected function getLocationRestId()
+    {
+        if ($this->request->attributes->get('location')) {
+            return $this->router->generate(
+                'ezpublish_rest_loadLocation',
+                ['locationPath' => trim($this->request->attributes->get('location')->pathString, '/')]
+            );
+        }
+        return "false";
+    }
+
+    public function __toString()
+    {
+        $selected = $this->getLocationRestId();
+        $id = $this->getLocationId();
+        // could be rendered with a twig template
+        return '<ez-browse selected-location-id="' . $selected . '" location-id="' . $id . '">Browse</ez-browse>';
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'selector' => 'ez-browse',
+            'update' => [
+                'attributes' => [
+                    'selected-location-id' => $this->getLocationRestId(),
+                    'location-id' => $this->getLocationId(),
+                ],
+            ],
+        ];
+    }
+}

--- a/src/lib/Components/Component.php
+++ b/src/lib/Components/Component.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+interface Component extends \JsonSerializable
+{
+    public function __toString();
+}

--- a/src/lib/Components/MainContent.php
+++ b/src/lib/Components/MainContent.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+// TODO find a better name
+class MainContent implements Component
+{
+    const TAG_NAME = 'ez-main-content';
+
+    protected $templating;
+
+    protected $template = null;
+
+    protected $parameters = [];
+
+    protected $result = false;
+
+    public function __construct($templating)
+    {
+        $this->templating = $templating;
+    }
+
+    public function setTemplate($template)
+    {
+        $this->template = $template;
+    }
+
+    public function setParameters($parameters)
+    {
+        $this->parameters = $parameters;
+    }
+
+    public function setResult($result)
+    {
+        $this->result = $result;
+    }
+
+    public function __toString()
+    {
+        $str = '<' . self::TAG_NAME . '>';
+        if ($this->result) {
+            $str .= $this->result;
+        } elseif ($this->template) {
+            $str .= $this->templating->render(
+                $this->template,
+                $this->parameters
+            );
+        }
+        $str .= '</' . self::TAG_NAME . '>';
+
+        return $str;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'selector' => self::TAG_NAME,
+            'update' => (string)$this,
+        ];
+    }
+}

--- a/src/lib/Components/NavigationHub.php
+++ b/src/lib/Components/NavigationHub.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class NavigationHub implements Component
+{
+    const TAG_NAME = 'ez-navigation-hub';
+
+    const ACTIVE_ZONE_CLASS = 'ez-active-zone';
+
+    const MATCHED_LINK_CLASS = 'ez-matched-link';
+
+    /**
+     * @var \Twig_Environment
+     */
+    protected $templating;
+
+    /**
+     * @var \EzSystems\PlatformUIBundle\NavigationHub\Zone[]
+     */
+    protected $zones;
+
+    /**
+     * @var \EzSystems\PlatformUIBundle\NavigationHub\Link[]
+     */
+    protected $links;
+
+    /**
+     * @var \Symfony\Component\HttpFoundation\Request
+     */
+    protected $request;
+
+    public function __construct($templating, RequestStack $stack, array $zones = [], array $links = [])
+    {
+        $this->request = $stack->getMasterRequest();
+        $this->templating = $templating;
+        $this->zones = $zones;
+        $this->links = $links;
+    }
+
+    public function __toString()
+    {
+        return $this->templating->render(
+            'eZPlatformUIBundle:Components:navigationhub.html.twig',
+            [
+                'tag' => self::TAG_NAME,
+                'attributes' => $this->getAttributes(),
+                'zones' => $this->zones,
+                'links' => $this->links,
+                'activeZone' => $this->getActiveZoneIdentifier(),
+                'activeZoneClass' => self::ACTIVE_ZONE_CLASS,
+                'matchedLinkClass' => self::MATCHED_LINK_CLASS,
+            ]
+        );
+    }
+
+    protected function getActiveLink()
+    {
+        foreach ($this->links as $link) {
+            if ($link->match($this->request)) {
+                return $link;
+            }
+        }
+
+        return null;
+    }
+
+    protected function getActiveZoneIdentifier()
+    {
+        $link = $this->getActiveLink();
+        if ($link) {
+            return $link->zone;
+        }
+        return '';
+    }
+
+    protected function getActiveLinkUrl()
+    {
+        $link = $this->getActiveLink();
+
+        if ($link) {
+            return $link->getUrl();
+        }
+        return '';
+    }
+
+    protected function getAttributes()
+    {
+        return [
+            'active-zone-class' => self::ACTIVE_ZONE_CLASS,
+            'matched-link-class' => self::MATCHED_LINK_CLASS,
+            'active-zone' => $this->getActiveZoneIdentifier(),
+            'matched-link-url' => $this->getActiveLinkUrl(),
+        ];
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'selector' => self::TAG_NAME,
+            'update' => [
+                'attributes' => $this->getAttributes(),
+            ]
+        ];
+    }
+}

--- a/src/lib/Components/Search.php
+++ b/src/lib/Components/Search.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+class Search implements Component
+{
+    public function __toString()
+    {
+        return '<div>Dumb thing, never updated</div>';
+    }
+
+    public function jsonSerialize()
+    {
+        return false;
+    }
+}

--- a/src/lib/Components/Toolbar.php
+++ b/src/lib/Components/Toolbar.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+class Toolbar implements Component
+{
+    protected $children;
+
+    protected $id;
+
+    protected $visible;
+
+    public function __construct($id, array $children)
+    {
+        $this->id = $id;
+        $this->children = $children;
+    }
+
+    protected function getVisibleValue()
+    {
+        return $this->visible ? 'true' : 'false';
+    }
+
+    public function __toString()
+    {
+        $html = '<ez-toolbar id="' . $this->id . '" visible="' . $this->getVisibleValue() . '">';
+        foreach ($this->children as $component) {
+            $html .= (string)$component;
+        }
+        $html .= '</ez-toolbar>';
+
+        return $html;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setVisible($visible)
+    {
+        $this->visible = $visible;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'selector' => '#' . $this->id,
+            'update' => [
+                'attributes' => [
+                    'visible' => $this->getVisibleValue(),
+                ],
+                'children' => $this->children,
+            ],
+        ];
+    }
+}

--- a/src/lib/Components/Trash.php
+++ b/src/lib/Components/Trash.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+class Trash implements Component
+{
+    public function __toString()
+    {
+        return '<div class="ez-trash-button">Server side updated at <b>' . date('H:i:s') . '</b></div>';
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'selector' => '.ez-trash-button',
+            'update' => (string)$this,
+        ];
+    }
+}

--- a/src/lib/EventSubscriber/AppRendererSubscriber.php
+++ b/src/lib/EventSubscriber/AppRendererSubscriber.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\EventSubscriber;
+
+use EzSystems\HybridPlatformUi\App\AppResponseRenderer;
+use EzSystems\HybridPlatformUi\Components\App;
+use EzSystems\HybridPlatformUi\Components\Component;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class AppRendererSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestMatcherInterface
+     */
+    private $adminRequestMatcher;
+
+    /**
+     * @var \EzSystems\HybridPlatformUi\Components\App
+     */
+    private $app;
+    /**
+     * @var \EzSystems\HybridPlatformUi\App\AppResponseRenderer
+     */
+    private $appRenderer;
+
+    public function __construct(
+        App $app,
+        AppResponseRenderer $appRenderer,
+        RequestMatcherInterface $adminRequestMatcher
+    ) {
+        $this->adminRequestMatcher = $adminRequestMatcher;
+        $this->app = $app;
+        $this->appRenderer = $appRenderer;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::VIEW => ['renderApp', 5]];
+    }
+
+    public function renderApp(GetResponseForControllerResultEvent $event)
+    {
+        if ($event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!$this->adminRequestMatcher->matches($request)) {
+            return;
+        }
+
+        if (!($controllerResult = $event->getControllerResult()) instanceof Component) {
+            return;
+        }
+
+        $this->app->setConfig([
+            'mainContent' => $event->getControllerResult(),
+            'toolbars' => ['discovery' => 1],
+        ]);
+
+        $event->setResponse(new Response());
+        $this->appRenderer->render($event->getResponse(), $this->app);
+    }
+}

--- a/src/lib/EventSubscriber/ComponentRendererSubscriber.php
+++ b/src/lib/EventSubscriber/ComponentRendererSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\EventSubscriber;
+
+use EzSystems\HybridPlatformUi\Components\Component;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ComponentRendererSubscriber implements EventSubscriberInterface
+{
+    private $ajaxUpdateRequestMatcher;
+
+    public function __construct(RequestMatcherInterface $ajaxUpdateRequestMatcher)
+    {
+        $this->ajaxUpdateRequestMatcher = $ajaxUpdateRequestMatcher;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::VIEW => ['renderComponent']];
+    }
+
+    public function renderComponent(GetResponseForControllerResultEvent $event)
+    {
+        if (!($component = $event->getControllerResult()) instanceof Component) {
+            return;
+        }
+
+        $response = $this->ajaxUpdateRequestMatcher->matches($event->getRequest()) ?
+            new JsonResponse($component) :
+            new Response($component);
+
+        $event->setResponse($response);
+    }
+}

--- a/src/lib/EventSubscriber/CoreViewSubscriber.php
+++ b/src/lib/EventSubscriber/CoreViewSubscriber.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\EventSubscriber;
+
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\HybridPlatformUi\Mapper\MainContentMapper;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Remaps an EzPublishCore controller view admin requests to a MainComponent.
+ */
+class CoreViewSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestMatcherInterface
+     */
+    private $adminRequestMatcher;
+
+    /**
+     * @var \EzSystems\HybridPlatformUi\Mapper\MainContentMapper
+     */
+    private $mapper;
+
+    public function __construct(
+        MainContentMapper $coreViewMapper,
+        RequestMatcherInterface $adminRequestMatcher
+    ) {
+        $this->adminRequestMatcher = $adminRequestMatcher;
+        $this->mapper = $coreViewMapper;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::VIEW => ['mapAdminViewToMainComponent', 10]];
+    }
+
+    public function mapAdminViewToMainComponent(GetResponseForControllerResultEvent $event)
+    {
+        if (!$this->adminRequestMatcher->matches($event->getRequest())) {
+            return;
+        }
+
+        if (!($view = $event->getControllerResult()) instanceof View) {
+            return;
+        }
+
+        $event->setControllerResult($this->mapper->map($view));
+    }
+}

--- a/src/lib/EventSubscriber/PjaxResponseSubscriber.php
+++ b/src/lib/EventSubscriber/PjaxResponseSubscriber.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUi\EventSubscriber;
+
+use EzSystems\HybridPlatformUi\App\AppResponseRenderer;
+use EzSystems\HybridPlatformUi\Components\App;
+use EzSystems\HybridPlatformUi\Mapper\PjaxResponseMainContentMapper;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Catches admin PJAX requests, and maps them to Hybrid views.
+ */
+class PjaxResponseSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestMatcherInterface
+     */
+    private $adminRequestMatcher;
+
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestMatcherInterface
+     */
+    private $pjaxRequestMatcher;
+
+    /**
+     * @var \EzSystems\HybridPlatformUi\Mapper\PjaxResponseMainContentMapper
+     */
+    private $responseMapper;
+
+    /**
+     * @var \EzSystems\HybridPlatformUi\Components\App
+     */
+    private $app;
+
+    /**
+     * @var \EzSystems\HybridPlatformUi\App\AppResponseRenderer
+     */
+    private $appRenderer;
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::RESPONSE => ['mapPjaxResponseToHybridResponse', 10]];
+    }
+
+    public function __construct(
+        App $app,
+        AppResponseRenderer $appRenderer,
+        PjaxResponseMainContentMapper $responseMapper,
+        RequestMatcherInterface $adminRequestMatcher,
+        RequestMatcherInterface $pjaxRequestMatcher
+    ) {
+        $this->adminRequestMatcher = $adminRequestMatcher;
+        $this->app = $app;
+        $this->appRenderer = $appRenderer;
+        $this->pjaxRequestMatcher = $pjaxRequestMatcher;
+        $this->responseMapper = $responseMapper;
+    }
+
+    public function mapPjaxResponseToHybridResponse(FilterResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if (
+            $event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST ||
+            !$this->adminRequestMatcher->matches($request) ||
+            !$this->pjaxRequestMatcher->matches($request)
+        ) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        if ($response instanceof RedirectResponse) {
+            $event->setResponse(
+                new RedirectResponse($response->headers->get('PJAX-Location'))
+            );
+            $event->stopPropagation();
+            return;
+        }
+
+        $this->app->setConfig([
+            'mainContent' => $this->responseMapper->map($response),
+            'toolbars' => ['discovery' => 1],
+        ]);
+
+        $this->appRenderer->render($event->getResponse(), $this->app);
+    }
+}

--- a/src/lib/Http/AjaxUpdateRequestMatcher.php
+++ b/src/lib/Http/AjaxUpdateRequestMatcher.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Http;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+class AjaxUpdateRequestMatcher implements RequestMatcherInterface
+{
+    public function matches(Request $request)
+    {
+        return (bool)$request->headers->get('x-ajax-update', 0);
+    }
+}

--- a/src/lib/Http/HardcodedAdminRequestMatcher.php
+++ b/src/lib/Http/HardcodedAdminRequestMatcher.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Http;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+class HardcodedAdminRequestMatcher implements RequestMatcherInterface
+{
+    public function matches(Request $request)
+    {
+        // @todo can't be hardcoded
+        return strpos($request->getRequestUri(), '/admin') === 0;
+    }
+}

--- a/src/lib/Mapper/CoreViewMainContentMapper.php
+++ b/src/lib/Mapper/CoreViewMainContentMapper.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUi\Mapper;
+
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\HybridPlatformUi\Components\MainContent;
+
+class CoreViewMainContentMapper implements MainContentMapper
+{
+    /**
+     * @var MainContent
+     */
+    private $mainContent;
+
+    public function __construct(MainContent $mainContent)
+    {
+        $this->mainContent = $mainContent;
+    }
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\View\View $view
+     *
+     * @return \EzSystems\HybridPlatformUi\Components\MainContent
+     */
+    public function map($view)
+    {
+        if (!$view instanceof View) {
+            throw new \InvalidArgumentException('Expected an \eZ\Publish\Core\MVC\Symfony\View\View');
+        }
+
+        $this->mainContent->setTemplate($view->getTemplateIdentifier());
+        $this->mainContent->setParameters($view->getParameters());
+
+        return $this->mainContent;
+    }
+}

--- a/src/lib/Mapper/MainContentMapper.php
+++ b/src/lib/Mapper/MainContentMapper.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUi\Mapper;
+
+use EzSystems\PlatformUIBundle\Components\MainContent;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Maps an object to a MainComponent.
+ */
+interface MainContentMapper
+{
+    /**
+     * @param mixed $value
+     *
+     * @return \EzSystems\HybridPlatformUi\Components\MainContent
+     */
+    public function map($value);
+}

--- a/src/lib/Mapper/PjaxResponseMainContentMapper.php
+++ b/src/lib/Mapper/PjaxResponseMainContentMapper.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Mapper;
+
+use EzSystems\HybridPlatformUi\Components\MainContent;
+use Symfony\Component\HttpFoundation\Response;
+
+class PjaxResponseMainContentMapper implements MainContentMapper
+{
+    /**
+     * @var \EzSystems\HybridPlatformUi\Components\MainContent
+     */
+    private $mainContent;
+
+    public function __construct(MainContent $mainContent)
+    {
+        $this->mainContent = $mainContent;
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     *
+     * @return \EzSystems\HybridPlatformUi\Components\MainContent
+     * @throws \Exception
+     */
+    public function map($response)
+    {
+        if (!$response instanceof Response) {
+            throw new \InvalidArgumentException('Expected a \Symfony\Component\HttpFoundation\Response');
+        }
+
+        $responseContent = $response->getContent();
+
+        $errorHandling = libxml_use_internal_errors(true);
+
+        $doc = new \DOMDocument();
+        if (!$doc->loadHTML($responseContent)) {
+            $errors = libxml_get_errors();
+            libxml_use_internal_errors($errorHandling);
+            throw new \Exception(
+                "Error(s) occurred parsing the PJAX response:\n" .
+                implode("\n", $errors)
+            );
+        }
+
+        $xpath = new \DOMXPath($doc);
+        $nodeList = $xpath->query('//div[@data-name="title"]');
+        $title = $nodeList[0]->nodeValue;
+        $contentNodeList = $xpath->query('//div[@data-name="html"]//section[contains(concat(" ", normalize-space(@class), " "), " ez-serverside-content ")]');
+
+        $contentNode = $contentNodeList[0];
+        $attributes = 'ez-view-serversideview';
+        foreach (explode(' ', $contentNode->getAttribute('class')) as $classAttribute) {
+            if ($classAttribute !== 'ez-view-serversideview') {
+                $attributes .= " $classAttribute";
+            }
+        }
+        $content =
+            '<div class="'.$attributes.'">' .
+            $this->innerHtml($contentNode) .
+            '</div>';
+
+        // @todo Should a service be used for main_content ? So that it is not necessary to carry templating around like this.
+        $this->mainContent->setResult($content);
+        // @todo add a Title to the mainComponent again
+        // $component->setTitle($title);
+
+        libxml_use_internal_errors($errorHandling);
+
+        return $this->mainContent;
+    }
+
+    private function innerHtml(\DOMElement $element)
+    {
+        $doc = $element->ownerDocument;
+
+        $html = '';
+
+        foreach ($element->childNodes as $node) {
+            $html .= $doc->saveHTML($node);
+        }
+
+        return $html;
+    }
+}

--- a/src/lib/NavigationHub/Link.php
+++ b/src/lib/NavigationHub/Link.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\NavigationHub;
+
+use Symfony\Component\HttpFoundation\Request;
+
+abstract class Link
+{
+    public $zone;
+
+    public $name;
+
+    abstract public function match(Request $request);
+}

--- a/src/lib/NavigationHub/Link/Route.php
+++ b/src/lib/NavigationHub/Link/Route.php
@@ -1,0 +1,57 @@
+<?php
+namespace EzSystems\HybridPlatformUi\NavigationHub\Link;
+
+use EzSystems\HybridPlatformUi\NavigationHub\Link;
+use Symfony\Component\HttpFoundation\Request;
+
+class Route extends Link
+{
+    protected $router;
+
+    protected $routeName;
+
+    protected $routeParams;
+
+    public function __construct($router, $routeName, $routeParams, $name, $zoneIdentifier)
+    {
+        $this->router = $router;
+        $this->zone = $zoneIdentifier;
+        $this->name = $name;
+        $this->routeName = $routeName;
+        $this->routeParams = $routeParams;
+    }
+
+    public function getUrl()
+    {
+        return $this->router->generate($this->routeName, $this->routeParams);
+    }
+
+    public function match(Request $request)
+    {
+        $routeName = $request->attributes->get('_route');
+        $routeParams = $request->attributes->get('_routeParams', []);
+
+        return (
+            $this->matchRoute($routeName)
+            && $this->matchRouteParams($routeParams)
+        );
+    }
+
+    protected function matchRoute($routeName)
+    {
+        return $routeName === $this->routeName;
+    }
+
+    protected function matchRouteParams($params)
+    {
+        if (count($params) !== count($this->routeParams)) {
+            return false;
+        }
+        foreach ($params as $name => $value) {
+            if (!isset($this->routeParams[$name]) || $this->routeParams[$name] !== $value) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/lib/NavigationHub/Link/Subtree.php
+++ b/src/lib/NavigationHub/Link/Subtree.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\NavigationHub\Link;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class Subtree extends Route
+{
+    public function match(Request $request)
+    {
+        $location = $request->attributes->get('location');
+
+        return
+            $this->matchRoute($this->routeName)
+            && $location
+            && in_array((string)$this->routeParams['locationId'], $location->path)
+        ;
+    }
+}

--- a/src/lib/NavigationHub/Zone.php
+++ b/src/lib/NavigationHub/Zone.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\NavigationHub;
+
+class Zone
+{
+    public $name;
+
+    public $identifier;
+
+    public function __construct($name, $identifier)
+    {
+        $this->name = $name;
+        $this->identifier = $identifier;
+    }
+}

--- a/src/lib/Platform/AdminSiteAccessConfigurationFilter.php
+++ b/src/lib/Platform/AdminSiteAccessConfigurationFilter.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUi\Platform;
+
+use eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessConfigurationFilter;
+
+class AdminSiteAccessConfigurationFilter implements SiteAccessConfigurationFilter
+{
+    public function filter(array $configuration)
+    {
+        $multiSite = count($configuration['groups']) > 1;
+        $updatedConfiguration = $configuration;
+        $updatedConfiguration['groups']['admin_group'] = [];
+
+        foreach (array_keys($configuration['groups']) as $groupName) {
+            $adminSiteAccessName = $multiSite
+                ? str_replace('_group', '', $groupName) . '_admin'
+                : 'admin';
+            $updatedConfiguration['list'][] = $adminSiteAccessName;
+            $updatedConfiguration['groups'][$groupName][] = $adminSiteAccessName;
+            $updatedConfiguration['groups']['admin_group'][] = $adminSiteAccessName;
+        }
+
+        return $updatedConfiguration;
+    }
+}

--- a/src/lib/View/Renderer/PjaxViewRenderer.php
+++ b/src/lib/View/Renderer/PjaxViewRenderer.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\View\Renderer;
+
+use eZ\Publish\Core\MVC\Symfony\View\Renderer;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\PlatformUIBundle\Hybrid\View\PjaxViewToDelete;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Renders an admin view to JSON.
+ *
+ * Unless the View has specific Hybrid UI handling, the View is rendered
+ * as an `update`.
+ */
+class PjaxViewRenderer implements Renderer
+{
+    public function render(View $view)
+    {
+        if (!$view instanceof PjaxViewToDelete) {
+            throw new \Exception("Given argument is not a PjaxView");
+        }
+
+        return new Response($view->getContent());
+    }
+}


### PR DESCRIPTION
Long story short, the hybrid UI Symfony architecture, as a unique commit.

Long story, this was moved from PlatformUI where it was initially prototyped. Most of the important pieces, and the basic Symfony architecture, should be in a correct state for a first "version" (not tag).

It should be reworked in decent sized commits before it gets merged to master.

### TODO
_The done parts are in the `dev` branch_

- [ ] Open dev branch pull-request
- [x] Split Admin SiteAccess configurator (link to story)
- [x] Split Toolbars (Components, templates, services, CompilerPass, Bundle)
- [x] Split NavigationHub (Components, templates, services, CompilerPass, Bundle)
- [x] Split MainContent (Component, Renderer)
- [ ] Split Dashboard (route, template, controller action)
- [ ] Split LocationView (route, template, controller action if there is one, view configuration)
- [x] Split Core View integration (Mapper, Renderer)
- [x] Split PJAX bridge (link to story/epic)
