### PR TITLE
Hybrid UI architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /vendor/
 composer.lock
+bin/doctrine-dbal
+bin/php-parse
+bin/phpspec
+bin/security-checker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: php
+
+php:
+    - 5.6
+    - 7.0
+
+# test only master (+ Pull requests)
+branches:
+    only:
+        - master
+
+before_script:
+    - travis_retry composer selfupdate
+    - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    - travis_retry composer install --prefer-dist --no-interaction
+
+script: ./bin/phpspec run --format=pretty
+
+notifications:
+    email: false

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,69 @@
+# Installation
+
+## Current development version
+Custom repositories and requirements must be set at root level during the current development phase.
+Edit the file, and add the following blocks:
+
+```json
+    "require": {
+        "composer/installers": "dev-ezplatform_assets as 1.3.x-dev",
+        "dpobel/ez-field-edit": "dev-master as 1.0.x-dev",
+        "dpobel/ez-map": "dev-master as 1.0.x-dev",
+        "dpobel/hybrid-platformui-assets": "~0.3"
+    }
+```
+
+```json
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/dpobel/ez-field-edit.git"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/dpobel/hybrid-platformui-assets.git"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/dpobel/installers.git"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/dpobel/ez-map.git"
+        }
+    ]
+```
+## Requirements
+From eZ Platform 1.9.0 or higher, run:
+
+    composer require ezsystems/hybrid-platform-ui:^0.1@dev
+
+## Bundles
+Edit `src/AppKernel.php`, and add the `EzSystemsHybridUiBundle` and `FOSJsRoutingBundle` to the list:
+
+    $bundles = array(
+        // ...
+        new EzSystems\HybridPlatformUiBundle\EzSystemsHybridPlatformUiBundle(),
+        new FOS\JsRoutingBundle\FOSJsRoutingBundle(),
+        new AppBundle\AppBundle(),
+    );
+
+## Routes
+Register the required routes. Edit `app/config/routing.yml`, and add the following lines:
+
+    fos_js_routing:
+        resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"
+
+    ez_platform_hybrid_ui:
+        resource: "@EzSystemsHybridPlatformUiBundle/Resources/config/routing.yml"
+
+## Assets
+Update the assets by running the following command:
+
+    # Symfony 2
+    php app/console assets:install --symlink web
+    
+    # Symfony 3
+    php bin/console assets:install --symlink web
+
+

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,68 +2,7 @@
 
 ## Current development version
 Custom repositories and requirements must be set at root level during the current development phase.
-Edit the file, and add the following blocks:
+For now, you should checkout the branch from [ezsystems/ezplatform#177](https://github.com/ezsystems/ezplatform/pull/177),
+and run composer update afterwards.
 
-```json
-    "require": {
-        "composer/installers": "dev-ezplatform_assets as 1.3.x-dev",
-        "dpobel/ez-field-edit": "dev-master as 1.0.x-dev",
-        "dpobel/ez-map": "dev-master as 1.0.x-dev",
-        "dpobel/hybrid-platformui-assets": "~0.3"
-    }
-```
-
-```json
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/dpobel/ez-field-edit.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/dpobel/hybrid-platformui-assets.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/dpobel/installers.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/dpobel/ez-map.git"
-        }
-    ]
-```
-## Requirements
-From eZ Platform 1.9.0 or higher, run:
-
-    composer require ezsystems/hybrid-platform-ui:^0.1@dev
-
-## Bundles
-Edit `src/AppKernel.php`, and add the `EzSystemsHybridUiBundle` and `FOSJsRoutingBundle` to the list:
-
-    $bundles = array(
-        // ...
-        new EzSystems\HybridPlatformUiBundle\EzSystemsHybridPlatformUiBundle(),
-        new FOS\JsRoutingBundle\FOSJsRoutingBundle(),
-        new AppBundle\AppBundle(),
-    );
-
-## Routes
-Register the required routes. Edit `app/config/routing.yml`, and add the following lines:
-
-    fos_js_routing:
-        resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"
-
-    ez_platform_hybrid_ui:
-        resource: "@EzSystemsHybridPlatformUiBundle/Resources/config/routing.yml"
-
-## Assets
-Update the assets by running the following command:
-
-    # Symfony 2
-    php app/console assets:install --symlink web
-    
-    # Symfony 3
-    php bin/console assets:install --symlink web
-
-
+Be careful, as this will checkout very early development branches of most packages.

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,23 @@
     "license": "GPL-2.0",
     "minimum-stability": "stable",
     "require": {
+        "ezsystems/platform-ui-bundle": "^1.9@dev",
+        "ezsystems/ezpublish-kernel": " ^6.9@dev",
+        "symfony/symfony": "~2.8 | ~3.0",
+        "friendsofsymfony/jsrouting-bundle": "^1.6"
     },
     "require-dev": {
+        "phpspec/phpspec": "^3.2",
+        "memio/spec-gen": "^0.6"
     },
     "autoload": {
+        "psr-4": {
+            "EzSystems\\HybridPlatformUiBundle\\": "src/bundle",
+            "EzSystems\\HybridPlatformUi\\": "src/lib",
+            "specs\\EzSystems\\HybridPlatformUi\\": "specs"
+        }
+    },
+    "config": {
+        "bin-dir": "bin"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,14 @@
     "license": "GPL-2.0",
     "minimum-stability": "stable",
     "require": {
-        "ezsystems/platform-ui-bundle": "^1.9@dev",
+        "ezsystems/platform-ui-bundle": "dev-proto_hybrid_package as 2.0.x-dev",
         "ezsystems/ezpublish-kernel": " ^6.9@dev",
         "symfony/symfony": "~2.8 | ~3.0",
-        "friendsofsymfony/jsrouting-bundle": "^1.6"
+        "friendsofsymfony/jsrouting-bundle": "^1.6",
+        "dpobel/ez-field-edit": "^1.0@dev",
+        "dpobel/ez-map": "^1.0@dev",
+        "dpobel/hybrid-platformui-assets": "^0.3",
+        "composer/installers": "^1.3@dev"
     },
     "require-dev": {
         "phpspec/phpspec": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,8 @@
         "ezsystems/ezpublish-kernel": " ^6.9@dev",
         "symfony/symfony": "~2.8 | ~3.0",
         "friendsofsymfony/jsrouting-bundle": "^1.6",
-        "dpobel/ez-field-edit": "^1.0@dev",
-        "dpobel/ez-map": "^1.0@dev",
-        "dpobel/hybrid-platformui-assets": "^0.3",
-        "composer/installers": "^1.3@dev"
+        "ezsystems/hybrid-platform-ui-assets": "^0.1",
+        "composer/installers": "dev-ezplatform_assets as 1.3.x-dev"
     },
     "require-dev": {
         "phpspec/phpspec": "^3.2",
@@ -26,5 +24,11 @@
     },
     "config": {
         "bin-dir": "bin"
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/dpobel/installers.git"
+        }
+    ]
 }

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,0 +1,13 @@
+extensions:
+    Memio\SpecGen\MemioSpecGenExtension: ~
+
+suites:
+    #hybrid_platform_ui_bundle:
+    #    namespace: EzSystems\HybridPlatformUiBundle
+    #    psr4_prefix: EzSystems\HybridPlatformUiBundle
+    #    src_path: ./src/bundle
+
+    hybrid_platform_ui:
+        namespace: EzSystems\HybridPlatformUi
+        psr4_prefix: EzSystems\HybridPlatformUi
+        src_path: ./src/lib

--- a/spec/App/RequestAppResponseRendererSpec.php
+++ b/spec/App/RequestAppResponseRendererSpec.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\App;
+
+use EzSystems\HybridPlatformUi\App\RequestAppResponseRenderer;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+class RequestAppResponseRendererSpec extends ObjectBehavior
+{
+    function let(
+        Request $request,
+        RequestMatcherInterface $ajaxUpdateRequestMatcher
+    ) {
+        $this->beConstructedWith($request, $ajaxUpdateRequestMatcher);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(RequestAppResponseRenderer::class);
+    }
+}

--- a/spec/EventSubscriber/AppRendererSubscriberSpec.php
+++ b/spec/EventSubscriber/AppRendererSubscriberSpec.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\EventSubscriber;
+
+use EzSystems\HybridPlatformUi\App\AppResponseRenderer;
+use EzSystems\HybridPlatformUi\Components\App;
+use EzSystems\HybridPlatformUi\Components\Component;
+use EzSystems\HybridPlatformUi\EventSubscriber\AppRendererSubscriber;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use stdClass;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @method array getSubscribedEvents()
+ * @method renderApp()
+ */
+class AppRendererSubscriberSpec extends ObjectBehavior
+{
+    function let(
+        App $app,
+        AppResponseRenderer $renderer,
+        GetResponseForControllerResultEvent $event,
+        Request $request,
+        Response $response,
+        ParameterBag $requestAttributes,
+        RequestMatcherInterface $adminRequestMatcher
+    ) {
+        $adminRequestMatcher->matches(Argument::type(Request::class))->willReturn(true);
+        $request->attributes = $requestAttributes;
+        $request->duplicate(Argument::cetera())->willReturn(new Request());
+
+        $event->getRequest()->willReturn($request);
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+        $event->getResponse()->willReturn($response);
+
+        $this->beConstructedWith($app, $renderer, $adminRequestMatcher);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AppRendererSubscriber::class);
+        $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    function it_subscribes_to_the_response_KernelEvent()
+    {
+        $this->getSubscribedEvents()->shouldBeArray();
+        $this->getSubscribedEvents()->shouldSubscribeToEvent(KernelEvents::RESPONSE);
+    }
+
+    function it_ignores_non_admin_requests(
+        AppResponseRenderer $renderer,
+        FilterResponseEvent $event,
+        Request $request,
+        RequestMatcherInterface $adminRequestMatcher,
+        Response $response
+    ) {
+        $adminRequestMatcher->matches($request)->willReturn(false);
+        $renderer->render($response)->shouldNotBeCalled();
+
+        $this->renderApp($event);
+    }
+
+    function it_ignores_sub_requests(FilterResponseEvent $event)
+    {
+        $event->getRequestType()->willReturn(HttpKernelInterface::SUB_REQUEST);
+        $event->getRequest()->shouldNotBeCalled();
+        $this->renderApp($event);
+    }
+
+    function it_renders_the_app(
+        App $app,
+        AppResponseRenderer $renderer,
+        FilterResponseEvent $event
+    ) {
+        $renderer->render(Argument::type(Response::class), $app)->shouldBeCalled();
+
+        $this->renderApp($event);
+
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'subscribeToEvent' => function (array $subscribedEvents, $event) {
+                return isset($subscribedEvents[$event])
+                    && is_array($subscribedEvents[$event])
+                    && count($subscribedEvents[$event]) === 2;
+            },
+            'havePriorityHigherThan' => function (array $subscribedEvents, $priority) {
+                $event = $subscribedEvents[KernelEvents::VIEW];
+                return isset($event[1]) && $event[1] > $priority;
+            },
+            'havePriorityLowerThan' => function (array $subscribedEvents, $priority) {
+                $event = $subscribedEvents[KernelEvents::VIEW];
+                return isset($event[1]) && $event[1] < $priority;
+            }
+        ];
+    }
+}

--- a/spec/EventSubscriber/ComponentRendererSubscriberSpec.php
+++ b/spec/EventSubscriber/ComponentRendererSubscriberSpec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\EventSubscriber;
+
+use EzSystems\HybridPlatformUi\EventSubscriber\ComponentRendererSubscriber;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+class ComponentRendererSubscriberSpec extends ObjectBehavior
+{
+    function let(RequestMatcherInterface $ajaxUpdateRequestMatcher)
+    {
+        $this->beConstructedWith($ajaxUpdateRequestMatcher);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ComponentRendererSubscriber::class);
+    }
+}

--- a/spec/EventSubscriber/CoreViewSubscriberSpec.php
+++ b/spec/EventSubscriber/CoreViewSubscriberSpec.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\EventSubscriber;
+
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\HybridPlatformUi\Components;
+use EzSystems\HybridPlatformUi\EventSubscriber\CoreViewSubscriber;
+use EzSystems\HybridPlatformUi\Mapper\MainContentMapper;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use stdClass;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @method array getSubscribedEvents()
+ * @method mapViewToComponent(GetResponseForControllerResultEvent $event)
+ */
+class CoreViewSubscriberSpec extends ObjectBehavior
+{
+    function let(
+        GetResponseForControllerResultEvent $event,
+        MainContentMapper $mapper,
+        Request $request,
+        RequestMatcherInterface $adminRequestMatcher,
+        View $view
+    ) {
+        $this->beConstructedWith($mapper, $adminRequestMatcher);
+        $event->getRequest()->willReturn($request);
+        $event->getControllerResult()->willReturn($view);
+        $adminRequestMatcher->matches($request)->willReturn(true);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CoreViewSubscriber::class);
+        $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    function it_subscribes_to_the_view_KernelEvent()
+    {
+        $this->getSubscribedEvents()->shouldBeArray();
+        $this->getSubscribedEvents()->shouldSubscribeToEvent(KernelEvents::VIEW);
+    }
+
+    function it_has_a_higher_priority_than_the_MVC_view_renderer()
+    {
+        $this->getSubscribedEvents()->shouldHavePriorityHigherThan(0);
+    }
+
+    function it_does_not_map_requests_without_a_view_as_controller_result(
+        GetResponseForControllerResultEvent $event,
+        MainContentMapper $mapper,
+        Request $request
+    ) {
+        $event->getControllerResult()->willReturn(new stdClass());
+
+        $mapper->map(Argument::any())->shouldNotBeCalled();
+
+        $this->mapAdminViewToMainComponent($event);
+    }
+
+    function it_does_not_map_non_admin_ui_requests(
+        GetResponseForControllerResultEvent $event,
+        Request $request,
+        RequestMatcherInterface $adminRequestMatcher
+    ) {
+        $adminRequestMatcher->matches($request)->willReturn(false);
+
+        $event->getControllerResult()->shouldNotBeCalled();
+
+        $this->mapAdminViewToMainComponent($event);
+    }
+
+    function it_maps_controller_results_that_are_views_to_the_MainContent_component(
+        GetResponseForControllerResultEvent $event,
+        Components\MainContent $mainContent,
+        MainContentMapper $mapper,
+        View $view
+    ) {
+        $event->getControllerResult()->willReturn($view);
+
+        $mapper->map($view)->willReturn($mainContent);
+        $event->setControllerResult($mainContent)->shouldBeCalled();
+
+        $this->mapAdminViewToMainComponent($event);
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'subscribeToEvent' => function (array $subscribedEvents, $event) {
+                return isset($subscribedEvents[$event])
+                    && is_array($subscribedEvents[$event])
+                    && count($subscribedEvents[$event]) === 2;
+            },
+            'havePriorityHigherThan' => function (array $subscribedEvents, $priority) {
+                return isset($subscribedEvents[KernelEvents::VIEW][1])
+                    && $subscribedEvents[KernelEvents::VIEW][1] > $priority;
+            }
+        ];
+    }
+}

--- a/spec/Http/AjaxUpdateRequestMatcherSpec.php
+++ b/spec/Http/AjaxUpdateRequestMatcherSpec.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\Http;
+
+use EzSystems\HybridPlatformUi\Http\AjaxUpdateRequestMatcher;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+class AjaxUpdateRequestMatcherSpec extends ObjectBehavior
+{
+    function let(
+        HeaderBag $headerBag,
+        Request $request
+    ) {
+        $request->headers = $headerBag;
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AjaxUpdateRequestMatcher::class);
+        $this->shouldHaveType(RequestMatcherInterface::class);
+    }
+
+    function it_matches_requests_with_the_x_ajax_update_header(
+        HeaderBag $headerBag,
+        Request $request
+    ) {
+        $headerBag->has('x-ajax-update')->willReturn(true);
+        $this->matches($request)->shouldBe(true);
+    }
+
+    function it_does_not_match_requests_with_the_x_ajax_update_header(
+        HeaderBag $headerBag,
+        Request $request
+    ) {
+        $headerBag->has('x-ajax-update')->willReturn(false);
+        $this->matches($request)->shouldBe(false);
+    }
+}

--- a/spec/Http/ChainRequestMatcherSpec.php
+++ b/spec/Http/ChainRequestMatcherSpec.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\Http;
+
+use EzSystems\HybridPlatformUi\Http\ChainRequestMatcher;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+class ChainRequestMatcherSpec extends ObjectBehavior
+{
+    function let(
+        RequestMatcherInterface $firstRequestMatcher,
+        RequestMatcherInterface $secondRequestMatcher
+    ) {
+        $this->beConstructedWith($firstRequestMatcher, $secondRequestMatcher);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ChainRequestMatcher::class);
+        $this->shouldHaveType(RequestMatcherInterface::class);
+    }
+
+    function it_can_be_constructed_with_any_number_of_request_matchers(
+        RequestMatcherInterface $firstRequestMatcher,
+        RequestMatcherInterface $secondRequestMatcher,
+        RequestMatcherInterface $thirdRequestMatcher,
+        RequestMatcherInterface $fourthRequestMatcher
+    ) {
+        $this->beConstructedWith(
+            $firstRequestMatcher,
+            $secondRequestMatcher,
+            $thirdRequestMatcher,
+            $fourthRequestMatcher
+        );
+    }
+
+    function it_matches_if_all_matchers_match(
+        Request $request,
+        RequestMatcherInterface $firstRequestMatcher,
+        RequestMatcherInterface $secondRequestMatcher
+    ) {
+        $firstRequestMatcher->matches($request)->willReturn(true);
+        $secondRequestMatcher->matches($request)->willReturn(true);
+
+        $this->matches($request)->shouldBe(true);
+    }
+
+    function it_does_not_match_if_at_least_one_matcher_does_not_match(
+        Request $request,
+        RequestMatcherInterface $firstRequestMatcher,
+        RequestMatcherInterface $secondRequestMatcher
+    ) {
+        $firstRequestMatcher->matches($request)->willReturn(true);
+        $secondRequestMatcher->matches($request)->willReturn(false);
+
+        $this->matches($request)->shouldBe(false);
+    }
+}

--- a/spec/Http/HardcodedAdminRequestMatcherSpec.php
+++ b/spec/Http/HardcodedAdminRequestMatcherSpec.php
@@ -4,6 +4,7 @@ namespace spec\EzSystems\HybridPlatformUi\Http;
 
 use EzSystems\HybridPlatformUi\Http\HardcodedAdminRequestMatcher;
 use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 
@@ -12,6 +13,11 @@ use Symfony\Component\HttpFoundation\RequestMatcherInterface;
  */
 class HardcodedAdminRequestMatcherSpec extends ObjectBehavior
 {
+    function let(Request $request, ParameterBag $requestAttributes)
+    {
+        $request->attributes = $requestAttributes;
+    }
+
     function it_is_initializable()
     {
         $this->shouldHaveType(HardcodedAdminRequestMatcher::class);
@@ -22,6 +28,23 @@ class HardcodedAdminRequestMatcherSpec extends ObjectBehavior
         Request $request
     ) {
         $request->getRequestUri()->willReturn('/admin/foo');
+        $this->matches($request)->shouldEqual(true);
+
+        $request->getRequestUri()->willReturn('/other/path');
+        $this->matches($request)->shouldEqual(false);
+    }
+
+    function it_ignores_requests_with_an_excluded_route_prefix(
+        ParameterBag $requestAttributes,
+        Request $request
+    ) {
+        $request->getRequestUri()->willReturn('/admin/foo');
+        $this->setExcludedRoutesPrefixes(['excluded_']);
+
+        $requestAttributes->get('_route')->willReturn('excluded_route');
+        $this->matches($request)->shouldEqual(false);
+
+        $requestAttributes->get('_route')->willReturn('another_route');
         $this->matches($request)->shouldEqual(true);
     }
 }

--- a/spec/Http/HardcodedAdminRequestMatcherSpec.php
+++ b/spec/Http/HardcodedAdminRequestMatcherSpec.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\Http;
+
+use EzSystems\HybridPlatformUi\Http\HardcodedAdminRequestMatcher;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+/**
+ * @method bool matches(Request $request)
+ */
+class HardcodedAdminRequestMatcherSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(HardcodedAdminRequestMatcher::class);
+        $this->shouldHaveType(RequestMatcherInterface::class);
+    }
+
+    function it_matches_requests_to_the_admin_siteaccess(
+        Request $request
+    ) {
+        $request->getRequestUri()->willReturn('/admin/foo');
+        $this->matches($request)->shouldEqual(true);
+    }
+}

--- a/spec/Http/HtmlFormatRequestMatcherSpec.php
+++ b/spec/Http/HtmlFormatRequestMatcherSpec.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\Http;
+
+use EzSystems\HybridPlatformUi\Http\HtmlFormatRequestMatcher;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+class HtmlFormatRequestMatcherSpec extends ObjectBehavior
+{
+    function let(
+        ParameterBag $attributes,
+        Request $request
+    ) {
+        $request->attributes = $attributes;
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(HtmlFormatRequestMatcher::class);
+        $this->shouldHaveType(RequestMatcherInterface::class);
+    }
+
+    function it_matches_requests_with_html_format(
+        ParameterBag $attributes,
+        Request $request
+    ) {
+        $attributes->get('_format')->willReturn('html');
+        $this->match($request)->shouldBe(true);
+    }
+
+    function it_does_not_match_requests_with_html_format(
+        ParameterBag $attributes,
+        Request $request
+    ) {
+        $attributes->get('_format')->willReturn('js');
+
+        $this->match($request)->shouldBe(false);
+    }
+}

--- a/spec/Platform/AdminSiteAccessConfigurationFilterSpec.php
+++ b/spec/Platform/AdminSiteAccessConfigurationFilterSpec.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\Platform;
+
+use eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessConfigurationFilter;
+use EzSystems\HybridPlatformUi\Platform\AdminSiteAccessConfigurationFilter;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class AdminSiteAccessConfigurationFilterSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AdminSiteAccessConfigurationFilter::class);
+        $this->shouldHaveType(SiteAccessConfigurationFilter::class);
+    }
+
+    function it_creates_an_admin_siteaccess_if_there_is_only_one_group()
+    {
+        $configuration = [
+            'list' => ['site'],
+            'groups' => ['site_group' => ['site']],
+        ];
+        $this->filter($configuration)->shouldBe(
+            [
+                'list' => ['site', 'admin'],
+                'groups' => ['site_group' => ['site', 'admin'], 'admin_group' => ['admin']],
+            ]
+        );
+    }
+
+    function it_creates_an_admin_siteaccess_per_group_if_there_are_several_groups()
+    {
+        $configuration = [
+            'list' => ['bluegill', 'rocky'],
+            'groups' => [
+                'murloc_group' => ['bluegill'],
+                'troll_group' => ['rocky'],
+            ],
+        ];
+        $this->filter($configuration)->shouldBe(
+            $configuration = [
+                'list' => ['bluegill', 'rocky', 'murloc_admin', 'troll_admin'],
+                'groups' => [
+                    'murloc_group' => ['bluegill', 'murloc_admin'],
+                    'troll_group' => ['rocky', 'troll_admin'],
+                    'admin_group' => ['murloc_admin', 'troll_admin'],
+                ],
+            ]
+        );
+
+        $this->filter($configuration)->shouldDefineSiteAccessInGroup('troll_admin', 'troll_group');
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'defineSiteAccessInGroup' => function (array $configuration, $expectedSiteAccess, $group) {
+                return
+                    in_array($expectedSiteAccess, $configuration['list']) &&
+                    isset($configuration['groups'][$group]) &&
+                    in_array($expectedSiteAccess, $configuration['groups'][$group]);
+            }
+        ];
+    }
+}

--- a/spec/View/CoreViewMainContentMapperSpec.php
+++ b/spec/View/CoreViewMainContentMapperSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\View;
+
+use EzSystems\HybridPlatformUi\Components\MainContent;
+use EzSystems\HybridPlatformUi\View\CoreViewMainContentMapper;
+use PhpSpec\ObjectBehavior;
+
+class CoreViewMainContentMapperSpec extends ObjectBehavior
+{
+    function let(MainContent $mainContent)
+    {
+        $this->beConstructedWith($mainContent);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CoreViewMainContentMapper::class);
+    }
+}

--- a/src/bundle/Controller/DashboardController.php
+++ b/src/bundle/Controller/DashboardController.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * File containing the DashboardController class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\HybridPlatformUiBundle\Controller;
+
+use EzSystems\HybridPlatformUi\Components\App;
+use EzSystems\HybridPlatformUi\Components\MainContent;
+use EzSystems\PlatformUIBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\RouterInterface;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+class DashboardController extends Controller
+{
+    public function viewDashboardAction()
+    {
+        $mainContent = $this->container->get('ezsystems.platformui.component.maincontent');
+        $mainContent->setTemplate('EzSystemsHybridPlatformUiBundle::dashboard.html.twig');
+
+        return $mainContent;
+    }
+}

--- a/src/bundle/DependencyInjection/Compiler/NavigationHubPass.php
+++ b/src/bundle/DependencyInjection/Compiler/NavigationHubPass.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUiBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class NavigationHubPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('ezsystems.platformui.component.navigationhub')) {
+            return;
+        }
+
+        $this->processNavigationHubTag($container, 'ezplatform.ui.zone', 2);
+        $this->processNavigationHubTag($container, 'ezplatform.ui.link', 3);
+    }
+
+    private function processNavigationHubTag(ContainerBuilder $container, $tag, $index)
+    {
+        $items = [];
+        $services = $container->findTaggedServiceIds($tag);
+        foreach (array_keys($services) as $serviceId) {
+            $items[] = new Reference($serviceId);
+        }
+
+        $container
+            ->findDefinition('ezsystems.platformui.component.navigationhub')
+            ->replaceArgument($index, $items);
+    }
+}

--- a/src/bundle/DependencyInjection/Compiler/ToolbarsPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ToolbarsPass.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUiBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use LogicException;
+
+class ToolbarsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('ezsystems.platformui.component.app')) {
+            return;
+        }
+
+        $toolbars = [];
+        $toolbarsItems = [];
+
+        foreach ($container->findTaggedServiceIds('ezplatform.ui.toolbar_item') as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                if (!isset($tag['toolbar'])) {
+                    throw new LogicException("Missing mandatory tag attribute 'toolbar' for service " . $serviceId);
+                }
+                $toolbarsItems[$tag['toolbar']][] = new Reference($serviceId);
+            }
+        }
+
+        foreach ($container->findTaggedServiceIds('ezplatform.ui.toolbar') as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                if (!isset($tag['alias'])) {
+                    throw new LogicException("Missing mandatory tag attribute 'toolbar' for service ". $serviceId);
+                }
+
+                $toolbarDefinition = $container->findDefinition($serviceId);
+                $toolbarDefinition->replaceArgument(0, $tag['alias']);
+
+                if (isset($toolbarsItems[$tag['alias']])) {
+                    $toolbarDefinition->replaceArgument(1, $toolbarsItems[$tag['alias']]);
+                    unset($toolbarsItems[$tag['alias']]);
+                }
+
+                $toolbars[] = new Reference($serviceId);
+            }
+        }
+
+        if (count($toolbarsItems) > 0) {
+            $message =
+                "Services tagged as ezplatform.ui.toolbar_item were found that aren't attached to any toolbar: " .
+                implode(', ', array_keys($toolbarsItems));
+
+            throw new LogicException($message);
+        }
+
+        $container
+            ->findDefinition('ezsystems.platformui.component.app')
+            ->replaceArgument(3, $toolbars);
+    }
+}

--- a/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
+++ b/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
@@ -2,17 +2,20 @@
 
 namespace EzSystems\HybridPlatformUiBundle\DependencyInjection;
 
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * This is the class that loads and manages your bundle configuration.
  *
  * @link http://symfony.com/doc/current/cookbook/bundles/extension.html
  */
-class EzSystemsHybridPlatformUiExtension extends Extension
+class EzSystemsHybridPlatformUiExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * {@inheritdoc}
@@ -25,5 +28,18 @@ class EzSystemsHybridPlatformUiExtension extends Extension
         $loader->load('services.yml');
         $loader->load('toolbars.yml');
         $loader->load('components.yml');
+    }
+
+    public function prepend(ContainerBuilder $container)
+    {
+        $this->prependViewsConfiguration($container);
+    }
+
+    private function prependViewsConfiguration(ContainerBuilder $container)
+    {
+        $configFile = __DIR__ . '/../Resources/config/views.yml';
+        $config = Yaml::parse(file_get_contents($configFile));
+        $container->prependExtensionConfig('ezpublish', $config);
+        $container->addResource(new FileResource($configFile));
     }
 }

--- a/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
+++ b/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
@@ -20,5 +20,9 @@ class EzSystemsHybridPlatformUiExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+        $loader->load('navigationhub.yml');
+        $loader->load('toolbars.yml');
+        $loader->load('components.yml');
     }
 }

--- a/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
+++ b/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
@@ -24,5 +24,6 @@ class EzSystemsHybridPlatformUiExtension extends Extension
         $loader->load('navigationhub.yml');
         $loader->load('services.yml');
         $loader->load('toolbars.yml');
+        $loader->load('components.yml');
     }
 }

--- a/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
+++ b/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
@@ -20,9 +20,9 @@ class EzSystemsHybridPlatformUiExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
-        $loader->load('services.yml');
-        $loader->load('navigationhub.yml');
-        $loader->load('toolbars.yml');
         $loader->load('components.yml');
+        $loader->load('navigationhub.yml');
+        $loader->load('services.yml');
+        $loader->load('toolbars.yml');
     }
 }

--- a/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
+++ b/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace EzSystems\HybridPlatformUiBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration.
+ *
+ * @link http://symfony.com/doc/current/cookbook/bundles/extension.html
+ */
+class EzSystemsHybridPlatformUiExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+    }
+}

--- a/src/bundle/EzSystemsHybridPlatformUiBundle.php
+++ b/src/bundle/EzSystemsHybridPlatformUiBundle.php
@@ -3,6 +3,7 @@
 namespace EzSystems\HybridPlatformUiBundle;
 
 use EzSystems\HybridPlatformUi\Platform\AdminSiteAccessConfigurationFilter;
+use EzSystems\HybridPlatformUiBundle\DependencyInjection\Compiler\NavigationHubPass;
 use EzSystems\HybridPlatformUiBundle\DependencyInjection\Compiler\ToolbarsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -11,6 +12,7 @@ class EzSystemsHybridPlatformUiBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
+        $container->addCompilerPass(new NavigationHubPass());
         $container->addCompilerPass(new ToolbarsPass());
 
         $eZExtension = $container->getExtension('ezpublish');

--- a/src/bundle/EzSystemsHybridPlatformUiBundle.php
+++ b/src/bundle/EzSystemsHybridPlatformUiBundle.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace EzSystems\HybridPlatformUiBundle;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class EzSystemsHybridPlatformUiBundle extends Bundle
+{
+    public function build(ContainerBuilder $container)
+    {
+    }
+}

--- a/src/bundle/EzSystemsHybridPlatformUiBundle.php
+++ b/src/bundle/EzSystemsHybridPlatformUiBundle.php
@@ -3,6 +3,7 @@
 namespace EzSystems\HybridPlatformUiBundle;
 
 use EzSystems\HybridPlatformUi\Platform\AdminSiteAccessConfigurationFilter;
+use EzSystems\HybridPlatformUiBundle\DependencyInjection\Compiler\ToolbarsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -10,6 +11,8 @@ class EzSystemsHybridPlatformUiBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
+        $container->addCompilerPass(new ToolbarsPass());
+
         $eZExtension = $container->getExtension('ezpublish');
         $eZExtension->addSiteAccessConfigurationFilter(
             new AdminSiteAccessConfigurationFilter()

--- a/src/bundle/EzSystemsHybridPlatformUiBundle.php
+++ b/src/bundle/EzSystemsHybridPlatformUiBundle.php
@@ -2,6 +2,7 @@
 
 namespace EzSystems\HybridPlatformUiBundle;
 
+use EzSystems\HybridPlatformUi\Platform\AdminSiteAccessConfigurationFilter;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -9,5 +10,9 @@ class EzSystemsHybridPlatformUiBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
+        $eZExtension = $container->getExtension('ezpublish');
+        $eZExtension->addSiteAccessConfigurationFilter(
+            new AdminSiteAccessConfigurationFilter()
+        );
     }
 }

--- a/src/bundle/Resources/config/components.yml
+++ b/src/bundle/Resources/config/components.yml
@@ -1,0 +1,10 @@
+services:
+    ezsystems.platformui.component.app:
+        class: EzSystems\HybridPlatformUi\Components\App
+        arguments:
+            - "@templating"
+            - "@ezsystems.platformui.component.maincontent"
+            - "@ezsystems.platformui.component.navigationhub"
+            # @todo tag those services so that it's possible to add
+            # new toolbars
+            - ["@ezsystems.platformui.component.discoverybar"]

--- a/src/bundle/Resources/config/components.yml
+++ b/src/bundle/Resources/config/components.yml
@@ -8,3 +8,17 @@ services:
             # @todo tag those services so that it's possible to add
             # new toolbars
             - ["@ezsystems.platformui.component.discoverybar"]
+
+    ezsystems.platformui.component.navigationhub:
+        class: EzSystems\HybridPlatformUi\Components\NavigationHub
+        arguments:
+            - "@templating"
+            - '@=service("request_stack").getMasterRequest()'
+            - []
+            - []
+
+    ezsystems.platformui.component.maincontent:
+        class: EzSystems\HybridPlatformUi\Components\MainContent
+        arguments:
+            - "@templating"
+        shared: false

--- a/src/bundle/Resources/config/components.yml
+++ b/src/bundle/Resources/config/components.yml
@@ -8,6 +8,7 @@ services:
             # @todo tag those services so that it's possible to add
             # new toolbars
             - ["@ezsystems.platformui.component.discoverybar"]
+        public: false
 
     ezsystems.platformui.component.navigationhub:
         class: EzSystems\HybridPlatformUi\Components\NavigationHub
@@ -16,6 +17,7 @@ services:
             - '@=service("request_stack").getMasterRequest()'
             - []
             - []
+        public: false
 
     ezsystems.platformui.component.maincontent:
         class: EzSystems\HybridPlatformUi\Components\MainContent

--- a/src/bundle/Resources/config/navigationhub.yml
+++ b/src/bundle/Resources/config/navigationhub.yml
@@ -11,6 +11,7 @@ services:
             - "content"
         tags:
             - {name: ezplatform.ui.zone}
+        public: false
 
     ezsystems.platformui.navigationhub.zones.page:
         class: "%ezsystems.platformui.navigationhub.zone.class%"
@@ -19,6 +20,7 @@ services:
             - "page"
         tags:
             - {name: ezplatform.ui.zone}
+        public: false
 
     ezsystems.platformui.navigationhub.zones.performances:
         class: "%ezsystems.platformui.navigationhub.zone.class%"
@@ -27,6 +29,7 @@ services:
             - "performances"
         tags:
             - {name: ezplatform.ui.zone}
+        public: false
 
     ezsystems.platformui.navigationhub.zones.admin:
         class: "%ezsystems.platformui.navigationhub.zone.class%"
@@ -35,6 +38,7 @@ services:
             - "admin"
         tags:
             - {name: ezplatform.ui.zone}
+        public: false
 
     ezsystems.platformui.navigationhub.link.contentstructure:
         class: "%ezsystems.platformui.navigationhub.link.subtree.class%"
@@ -47,6 +51,7 @@ services:
             - "content"
         tags:
             - {name: ezplatform.ui.link}
+        public: false
 
     ezsystems.platformui.navigationhub.link.medialibrary:
         class: "%ezsystems.platformui.navigationhub.link.subtree.class%"
@@ -58,3 +63,4 @@ services:
             - "content"
         tags:
             - {name: ezplatform.ui.link}
+        public: false

--- a/src/bundle/Resources/config/navigationhub.yml
+++ b/src/bundle/Resources/config/navigationhub.yml
@@ -1,0 +1,60 @@
+parameters:
+    ezsystems.platformui.navigationhub.zone.class: EzSystems\HybridPlatformUi\NavigationHub\Zone
+    ezsystems.platformui.navigationhub.link.route.class: EzSystems\HybridPlatformUi\NavigationHub\Link\Route
+    ezsystems.platformui.navigationhub.link.subtree.class: EzSystems\HybridPlatformUi\NavigationHub\Link\Subtree
+
+services:
+    ezsystems.platformui.navigationhub.zones.content:
+        class: "%ezsystems.platformui.navigationhub.zone.class%"
+        arguments:
+            - "Content"
+            - "content"
+        tags:
+            - {name: ezplatform.ui.zone}
+
+    ezsystems.platformui.navigationhub.zones.page:
+        class: "%ezsystems.platformui.navigationhub.zone.class%"
+        arguments:
+            - "Page"
+            - "page"
+        tags:
+            - {name: ezplatform.ui.zone}
+
+    ezsystems.platformui.navigationhub.zones.performances:
+        class: "%ezsystems.platformui.navigationhub.zone.class%"
+        arguments:
+            - "Performances"
+            - "performances"
+        tags:
+            - {name: ezplatform.ui.zone}
+
+    ezsystems.platformui.navigationhub.zones.admin:
+        class: "%ezsystems.platformui.navigationhub.zone.class%"
+        arguments:
+            - "Admin Panel"
+            - "admin"
+        tags:
+            - {name: ezplatform.ui.zone}
+
+    ezsystems.platformui.navigationhub.link.contentstructure:
+        class: "%ezsystems.platformui.navigationhub.link.subtree.class%"
+        arguments:
+            - "@router"
+            # Should be Core content route
+            - "ez_urlalias"
+            - {"locationId": 2}
+            - "Content structure"
+            - "content"
+        tags:
+            - {name: ezplatform.ui.link}
+
+    ezsystems.platformui.navigationhub.link.medialibrary:
+        class: "%ezsystems.platformui.navigationhub.link.subtree.class%"
+        arguments:
+            - "@router"
+            - "ez_urlalias"
+            - {"locationId": 2}
+            - "Media Library"
+            - "content"
+        tags:
+            - {name: ezplatform.ui.link}

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -1,0 +1,5 @@
+ez_hybrid_platform_ui_dashboard:
+    path: /dashboard
+    defaults:
+        _controller: EzSystemsHybridPlatformUiBundle:Dashboard:viewDashboard
+    methods: [GET]

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -1,0 +1,3 @@
+services:
+    ezsystems.platformui.hybrid.request_matcher.admin:
+        class: EzSystems\HybridPlatformUi\Http\HardcodedAdminRequestMatcher

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -3,9 +3,11 @@ services:
         class: EzSystems\HybridPlatformUi\Http\HardcodedAdminRequestMatcher
         calls:
             - [setExcludedRoutesPrefixes, ['%ezpublish.default_router.non_siteaccess_aware_routes%']]
+        public: false
 
     ezsystems.platformui.hybrid.request_matcher.ajax_update:
         class: EzSystems\HybridPlatformUi\Http\AjaxUpdateRequestMatcher
+        public: false
 
     ezsystems.platformui.hybrid.event_subscriber.app_renderer:
         class: EzSystems\HybridPlatformUi\EventSubscriber\AppRendererSubscriber
@@ -21,6 +23,7 @@ services:
         arguments:
             - '@=service("request_stack").getMasterRequest()'
             - '@ezsystems.platformui.hybrid.request_matcher.ajax_update'
+        public: false
 
     ezsystems.platformui.hybrid.event_subscriber.component_renderer:
         class: EzSystems\HybridPlatformUi\EventSubscriber\ComponentRendererSubscriber
@@ -31,12 +34,14 @@ services:
 
     ezsystems.hybrid_platform_ui.http.request_matcher.html_format:
         class: EzSystems\HybridPlatformUi\Http\HtmlFormatRequestMatcher
+        public: false
 
     ezsystems.hybrid_platform_ui.http.request_matcher.hybrid:
         class: EzSystems\HybridPlatformUi\Http\ChainRequestMatcher
         arguments:
             - "@ezsystems.platformui.hybrid.request_matcher.admin"
             - "@ezsystems.hybrid_platform_ui.http.request_matcher.html_format"
+        public: false
 
     ezsystems.platformui.hybrid.event_subscriber.core_view:
         class: EzSystems\HybridPlatformUi\EventSubscriber\CoreViewSubscriber
@@ -50,3 +55,4 @@ services:
         class: EzSystems\HybridPlatformUi\View\CoreViewMainContentMapper
         arguments:
             - "@ezsystems.platformui.component.maincontent"
+        public: false

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -35,3 +35,16 @@ services:
         arguments:
             - "@ezsystems.platformui.hybrid.request_matcher.admin"
             - "@ezsystems.hybrid_platform_ui.http.request_matcher.html_format"
+
+    ezsystems.platformui.hybrid.event_subscriber.core_view:
+        class: EzSystems\HybridPlatformUi\EventSubscriber\CoreViewSubscriber
+        arguments:
+            - "@ezsystems.platformui.hybrid.mapper.core_view_to_main_content"
+            - "@ezsystems.platformui.hybrid.request_matcher.admin"
+        tags:
+            - {name: kernel.event_subscriber}
+
+    ezsystems.platformui.hybrid.mapper.core_view_to_main_content:
+        class: EzSystems\HybridPlatformUi\View\CoreViewMainContentMapper
+        arguments:
+            - "@ezsystems.platformui.component.maincontent"

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -1,6 +1,8 @@
 services:
     ezsystems.platformui.hybrid.request_matcher.admin:
         class: EzSystems\HybridPlatformUi\Http\HardcodedAdminRequestMatcher
+        calls:
+            - [setExcludedRoutesPrefixes, ['%ezpublish.default_router.non_siteaccess_aware_routes%']]
 
     ezsystems.platformui.hybrid.request_matcher.ajax_update:
         class: EzSystems\HybridPlatformUi\Http\AjaxUpdateRequestMatcher

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -1,3 +1,37 @@
 services:
     ezsystems.platformui.hybrid.request_matcher.admin:
         class: EzSystems\HybridPlatformUi\Http\HardcodedAdminRequestMatcher
+
+    ezsystems.platformui.hybrid.request_matcher.ajax_update:
+        class: EzSystems\HybridPlatformUi\Http\AjaxUpdateRequestMatcher
+
+    ezsystems.platformui.hybrid.event_subscriber.app_renderer:
+        class: EzSystems\HybridPlatformUi\EventSubscriber\AppRendererSubscriber
+        arguments:
+            - "@ezsystems.platformui.component.app"
+            - "@ezsystems.platform_ui.hybrid.app.request_app_response_renderer"
+            - "@ezsystems.hybrid_platform_ui.http.request_matcher.hybrid"
+        tags:
+            - {name: kernel.event_subscriber}
+
+    ezsystems.platform_ui.hybrid.app.request_app_response_renderer:
+        class: EzSystems\HybridPlatformUi\App\RequestAppResponseRenderer
+        arguments:
+            - '@=service("request_stack").getMasterRequest()'
+            - '@ezsystems.platformui.hybrid.request_matcher.ajax_update'
+
+    ezsystems.platformui.hybrid.event_subscriber.component_renderer:
+        class: EzSystems\HybridPlatformUi\EventSubscriber\ComponentRendererSubscriber
+        arguments:
+            - "@ezsystems.platformui.pjax.request_matcher"
+        tags:
+            - {name: kernel.event_subscriber}
+
+    ezsystems.hybrid_platform_ui.http.request_matcher.html_format:
+        class: EzSystems\HybridPlatformUi\Http\HtmlFormatRequestMatcher
+
+    ezsystems.hybrid_platform_ui.http.request_matcher.hybrid:
+        class: EzSystems\HybridPlatformUi\Http\ChainRequestMatcher
+        arguments:
+            - "@ezsystems.platformui.hybrid.request_matcher.admin"
+            - "@ezsystems.hybrid_platform_ui.http.request_matcher.html_format"

--- a/src/bundle/Resources/config/toolbars.yml
+++ b/src/bundle/Resources/config/toolbars.yml
@@ -1,0 +1,27 @@
+services:
+    ezsystems.platformui.component.discoverybar:
+        class: EzSystems\HybridPlatformUi\Components\Toolbar
+        arguments:
+            - ~
+            - []
+        tags:
+            - {name: ezplatform.ui.toolbar, alias: "discovery"}
+
+    ezsystems.platformui.component.search:
+        class: EzSystems\HybridPlatformUi\Components\Search
+        tags:
+            - {name: ezplatform.ui.toolbar_item, toolbar: "discovery"}
+
+    ezsystems.platformui.component.browse:
+        class: EzSystems\HybridPlatformUi\Components\Browse
+        arguments:
+            - '@=service("request_stack").getMasterRequest()'
+            - "@router"
+        tags:
+            - {name: ezplatform.ui.toolbar_item, toolbar: "discovery"}
+
+    ezsystems.platformui.component.trash:
+        class: EzSystems\HybridPlatformUi\Components\Trash
+        tags:
+            - {name: ezplatform.ui.toolbar_item, toolbar: "discovery"}
+

--- a/src/bundle/Resources/config/toolbars.yml
+++ b/src/bundle/Resources/config/toolbars.yml
@@ -6,11 +6,13 @@ services:
             - []
         tags:
             - {name: ezplatform.ui.toolbar, alias: "discovery"}
+        public: false
 
     ezsystems.platformui.component.search:
         class: EzSystems\HybridPlatformUi\Components\Search
         tags:
             - {name: ezplatform.ui.toolbar_item, toolbar: "discovery"}
+        public: false
 
     ezsystems.platformui.component.browse:
         class: EzSystems\HybridPlatformUi\Components\Browse
@@ -19,9 +21,10 @@ services:
             - "@router"
         tags:
             - {name: ezplatform.ui.toolbar_item, toolbar: "discovery"}
+        public: false
 
     ezsystems.platformui.component.trash:
         class: EzSystems\HybridPlatformUi\Components\Trash
         tags:
             - {name: ezplatform.ui.toolbar_item, toolbar: "discovery"}
-
+        public: false

--- a/src/bundle/Resources/config/views.yml
+++ b/src/bundle/Resources/config/views.yml
@@ -1,0 +1,7 @@
+system:
+    admin:
+        content_view:
+            full:
+                default:
+                    template: "EzSystemsHybridPlatformUiBundle::locationview.html.twig"
+                    match: true

--- a/src/bundle/Resources/public/webcomponents/ez-browse.html
+++ b/src/bundle/Resources/public/webcomponents/ez-browse.html
@@ -1,0 +1,78 @@
+<link rel="import" href="../../../assets/ezplatform/polymer/polymer-element.html">
+
+<style>
+ez-browse {
+    display: block;
+    cursor: pointer;
+}
+</style>
+
+<script>
+// Such web component is maybe a tad overkill solution. We could perfectly have
+// a button convention recognized by the app to run the UDW to browse to a Location.
+// Something like:
+//
+// <button class="ez-run-udw-to-browse" data-startinglocationid="blabla">
+//    Browse
+// </button>
+//
+// but the point of this component is also experiment a way to have really rich
+// component.
+class eZBrowse extends Polymer.Element {
+    static get is() {
+        return 'ez-browse';
+    }
+
+    static get properties() {
+        return {
+            "selectedLocationId": {
+                type: String,
+            },
+            "locationId": { // for now this one is just here for demo/display
+                type: Number,
+            },
+        };
+    }
+
+    constructor() {
+        super();
+        this.addEventListener('click', function (e) {
+            e.stopImmediatePropagation();
+            this._discoverContent();
+        }.bind(this));
+    }
+
+    _discoverContent() {
+        const event = new CustomEvent('contentDiscover', {
+            detail: {
+                title: "Browse",
+                oncancel: function () {
+                    console.log('CANCEL');
+                },
+                onconfirm: this._browseToSelection.bind(this),
+                startingLocationId: this.selectedLocationId !== "false" ? this.selectedLocationId : undefined,
+            },
+            bubbles: true,
+        });
+        this.dispatchEvent(event);
+    }
+
+    _browseToSelection(selection) {
+        const event = new CustomEvent('browseToContent', {
+            detail: selection,
+            bubbles: true,
+        });
+        this.dispatchEvent(event);
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+    }
+}
+
+customElements.define(eZBrowse.is, eZBrowse);
+</script>

--- a/src/bundle/Resources/public/webcomponents/ez-main-content.html
+++ b/src/bundle/Resources/public/webcomponents/ez-main-content.html
@@ -1,0 +1,20 @@
+<link rel="import" href="../../../assets/ezplatform/polymer/polymer-element.html">
+
+<style>
+ez-main-content {
+    display: block;
+}
+</style>
+
+<script>
+(function () {
+    // this is where we could detect the markup structure to enhance it (tabs, selection table, ...)
+    class eZMainContent extends Polymer.Element {
+        static get is() {
+            return 'ez-main-content';
+        }
+    }
+
+    customElements.define(eZMainContent.is, eZMainContent);
+})();
+</script>

--- a/src/bundle/Resources/public/webcomponents/ez-navigation-hub.html
+++ b/src/bundle/Resources/public/webcomponents/ez-navigation-hub.html
@@ -1,0 +1,132 @@
+<link rel="import" href="../../../assets/ezplatform/polymer/polymer-element.html">
+
+<style>
+ez-navigation-hub {
+    display: block;
+}
+
+ez-navigation-hub .ez-zone-list,
+ez-navigation-hub .ez-navigation {
+    padding: 0;
+}
+
+ez-navigation-hub .ez-zone-list li {
+    display: inline-block;
+    padding: 0.4em 0.5em;
+    list-style-type: none;
+}
+
+ez-navigation-hub .ez-navigation li {
+    display: inline-block;
+    padding: 0.1em 0.3em;
+    list-style-type: none;
+}
+
+ez-navigation-hub .ez-active-zone {
+    background: #ddd;
+}
+
+ez-navigation-hub .ez-matched-link {
+    border-bottom: 2px solid grey;
+}
+</style>
+
+<script>
+(function () {
+    class eZNavigationHub extends Polymer.Element {
+        static get is() {
+            return 'ez-navigation-hub';
+        }
+
+        static get properties() {
+            return {
+                "activeZoneClass": {
+                    type: String,
+                },
+                "matchedLinkClass": {
+                    type: String,
+                },
+                "activeZone": {
+                    type: String,
+                    observer: '_updateActiveZone',
+                },
+                "matchedLinkUrl": {
+                    type: String,
+                    observer: '_highlightLink',
+                },
+            };
+        }
+
+        constructor() {
+            super();
+            this.addEventListener('click', function (e) {
+                // TODO we need a Polyfill for Element#matches()
+                if ( e.target.matches('[data-zone-identifier] a') ) {
+                    e.preventDefault();
+                    this.activeZone = e.target.parentNode.getAttribute('data-zone-identifier');
+                }
+            }.bind(this));
+        }
+
+        _updateActiveZone(newValue, oldValue) {
+            this._highlightZone(oldValue, newValue);
+            this._updateNavigation(oldValue, newValue);
+        }
+
+        _getZone(identifier) {
+            return this.querySelector('[data-zone-identifier="' + identifier + '"]');
+        }
+
+        _highlightZone(oldZoneIdentifier, newZoneIdentifier) {
+            if ( oldZoneIdentifier ) {
+                this._getZone(oldZoneIdentifier).classList.remove(this.activeZoneClass);
+            }
+            if ( newZoneIdentifier ) {
+                this._getZone(newZoneIdentifier).classList.add(this.activeZoneClass);
+            }
+        }
+
+        _getZoneItems(identifier) {
+            return this.querySelectorAll('[data-zone="' + identifier + '"]');
+        }
+
+        _updateNavigation(oldZoneIdentifier, newZoneIdentifier) {
+            const forEach = Array.prototype.forEach;
+
+            if ( oldZoneIdentifier ) {
+                forEach.call(this._getZoneItems(oldZoneIdentifier), function (link) {
+                    link.setAttribute('style', 'display: none;');
+                });
+            }
+            if ( newZoneIdentifier ) {
+                forEach.call(this._getZoneItems(newZoneIdentifier), function (link) {
+                    link.removeAttribute('style');
+                });
+            }
+        }
+
+        _getItemByUrl(url) {
+            return this.querySelector('[href="' + url + '"]').parentNode;
+        }
+
+        _highlightLink(newUrl, oldUrl) {
+            if ( oldUrl ) {
+                this._getItemByUrl(oldUrl).classList.remove(this.matchedLinkClass);
+            }
+            if ( newUrl ) {
+                this._getItemByUrl(newUrl).classList.add(this.matchedLinkClass);
+            }
+        }
+
+        connectedCallback() {
+            super.connectedCallback();
+        }
+
+        disconnectedCallback() {
+            super.disconnectedCallback();
+        }
+    }
+
+    customElements.define(eZNavigationHub.is, eZNavigationHub);
+})();
+</script>

--- a/src/bundle/Resources/public/webcomponents/ez-platformui-app.html
+++ b/src/bundle/Resources/public/webcomponents/ez-platformui-app.html
@@ -1,0 +1,256 @@
+<link rel="import" href="../../../assets/ezplatform/polymer/polymer-element.html">
+
+<script>
+(function () {
+    function fetchUpdate(updateUrl) {
+        var headers;
+
+        headers = new Headers({
+            'X-AJAX-Update': '1',
+        });
+        return fetch(updateUrl, {
+            credentials: 'same-origin',
+            headers: headers,
+        }).then(function (response) {
+            return response.json();
+        });
+    }
+
+    function fetchForm(form, forceUrl) {
+        var headers,
+            data = new FormData(form),
+            // forcing the same url for now, but the form should have
+            // a correct action attribute value instead...
+            url = forceUrl;
+
+        data.append(form.ownerDocument.activeElement.name, "button");
+
+        headers = new Headers({
+            'X-AJAX-Update': '1',
+        });
+        return fetch(url, {
+            credentials: 'same-origin',
+            headers: headers,
+            method: form.method,
+            body: data,
+        }).then(function (response) {
+            return response.json();
+        });
+    }
+
+    function updateElement(element, updateStruct) {
+        if ( typeof updateStruct === "string" ) {
+            // this replaces element.outerHTML = updateStruct;
+            // because of https://github.com/webcomponents/custom-elements/issues/71
+            const doc = new DOMParser().parseFromString(updateStruct, "text/html");
+            element = element.parentNode.replaceChild(doc.body.firstChild, element);
+        } else if ( updateStruct ) {
+            let attributes = updateStruct.attributes || {},
+                children = updateStruct.children || [];
+
+            Object.keys(attributes).forEach(function (attributeName) {
+                element.setAttribute(attributeName, attributes[attributeName]);
+            });
+            children.forEach(function (childUpdate) {
+                if ( childUpdate ) {
+                    const child = element.querySelector(childUpdate.selector);
+
+                    if ( child ) {
+                        updateElement(child, childUpdate.update);
+                    } else {
+                        console.warn(`Unable to find ${childUpdate.selector} under`, element);
+                    }
+                }
+            }, element);
+        }
+        return updateStruct;
+    }
+
+    document.addEventListener('click', function (e) {
+        if ( e.target.classList.contains('run-udw') ) {
+            const button = e.target;
+            const event = new CustomEvent('contentDiscover', {
+                detail: {
+                    title: "UDW tests (multiple, allow only container)",
+                    multiple: true,
+                    oncancel: function () {
+                        console.log('CANCEL');
+                    },
+                    onconfirm: function (items) {
+                        var list = document.createElement('ul');
+                        items.forEach(function (selection) {
+                            const result = document.createElement('li');
+
+                            result.innerHTML = `${selection.location.contentInfo.name}
+                                (Content id #${selection.content.contentId}) in Location
+                                #${selection.location.locationId}
+                                (${selection.location.pathString}) was
+                                chosen (Type ${selection.contentType.names['eng-GB']})`;
+
+                            list.appendChild(result);
+                        });
+                        button.parentNode.insertBefore(list, button);
+                    },
+                    isSelectable: function (item) {
+                        return item.contentType.isContainer;
+                    },
+                },
+                bubbles: true,
+            });
+            button.dispatchEvent(event);
+        }
+    });
+
+    class PlatformUIApp extends Polymer.Element {
+        static get is() {
+            return 'ez-platformui-app';
+        }
+
+        static get properties() {
+            return {
+                updating: {
+                    type: Boolean,
+                    reflectToAttribute: true,
+                    value: false,
+                },
+                title: {
+                    type: String,
+                    reflectToAttribute: true,
+                    value: "",
+                    observer: '_setPageTitle',
+                },
+                url: {
+                    type: String,
+                    reflectToAttribute: true,
+                    value: location.href,
+                    observer: '_replaceHistory',
+                },
+            };
+        }
+
+        constructor() {
+            super();
+        }
+
+        connectedCallback() {
+            super.connectedCallback();
+            this._enhanceNavigation();
+            this._listenToBrowseToContent();
+            this._listenToContentDiscover();
+        }
+
+        disconnectedCallback() {
+            super.disconnectedCallback();
+        }
+
+        _setPageTitle(newValue, oldValue) {
+            if ( newValue ) {
+                this.ownerDocument.title = newValue;
+            }
+        }
+
+        _update(updateUrl) {
+            this.updating = true;
+
+            fetchUpdate(updateUrl)
+                .then(this._updateApp.bind(this))
+                .then(function (struct) {
+                    this.updating = false;
+
+                    return struct;
+                }.bind(this));
+        }
+
+        _updateForm(form) {
+            this.updating = true;
+
+            fetchForm(form, this.url)
+                .then(this._updateApp.bind(this))
+                .then(function (struct) {
+                    this.updating = false;
+
+                    return struct;
+                }.bind(this));
+        }
+
+        _replaceHistory() {
+            history.pushState({url: this.url}, this.title, this.url);
+        }
+
+        _updateApp(updateStruct) {
+            updateElement.call(null, this, updateStruct.update);
+        }
+
+        _enhanceNavigation() {
+            this.addEventListener('click', function (e) {
+                var updateUrl;
+
+                function isNavigationLink(element) {
+                    // TODO we need a Polyfill for Element#closest()
+                    var anchor = element.closest('a');
+
+                    // we should probably further check the URI (same origin ?)
+                    // we should also allow to opt out from that with a class
+                    return anchor && anchor.href && anchor.getAttribute('href').indexOf('#') !== 0
+                }
+
+                if ( isNavigationLink(e.target) ) {
+                    updateUrl = e.target.closest('a').href;
+                    e.preventDefault();
+                    this._update(updateUrl);
+                }
+            }.bind(this));
+            window.addEventListener('popstate', function (e) {
+                if ( e.state && e.state.url ) {
+                    this._update(e.state.url);
+                }
+            }.bind(this));
+
+            this.addEventListener('submit', function (e) {
+                e.preventDefault();
+                this._updateForm(e.target);
+            }.bind(this));
+
+        }
+
+        _listenToBrowseToContent() {
+            this.addEventListener('browseToContent', function (e) {
+                const uri = Routing.generate(
+                    'proto_viewLocation',
+                    {"locationId": e.detail.location.locationId}
+                );
+
+                this._update(uri);
+            }.bind(this));
+        }
+
+        _listenToContentDiscover() {
+            this.addEventListener('contentDiscover', function (e) {
+                const udw = document.createElement('ez-universaldiscoverywidget');
+
+                udw.title = e.detail.title;
+                udw.multiple = e.detail.multiple;
+                udw.onconfirm = function (selection) {
+                    e.detail.onconfirm.call(udw, selection);
+                    // removing the UDW is a bit brutal as this prevents
+                    // any kind of animation when hiding the UDW.
+                    udw.remove(true);
+                }
+                udw.oncancel = function (selection) {
+                    if ( e.detail.oncancel ) {
+                        e.detail.oncancel.call(udw, selection);
+                    }
+                    udw.remove(true);
+                }
+                udw.isSelectable = e.detail.isSelectable ? e.detail.isSelectable : undefined;
+                udw.startingLocationId = e.detail.startingLocationId;
+                // that way existing PlatformUI stylesheets work out of the box
+                udw.classList.add('ez-universaldiscovery-container');
+                this.appendChild(udw);
+            }.bind(this));
+        }
+    }
+
+    customElements.define(PlatformUIApp.is, PlatformUIApp);
+})();
+</script>

--- a/src/bundle/Resources/public/webcomponents/ez-subitem.html
+++ b/src/bundle/Resources/public/webcomponents/ez-subitem.html
@@ -1,0 +1,122 @@
+<link rel="import" href="../../../assets/ezplatform/polymer/polymer-element.html">
+<link rel="import" href="../../../webcomponents/ez-yui-app.html">
+
+<style>
+ez-subitem {
+    display: block;
+    width: 100%;
+    margin: 1em 0;
+}
+</style>
+
+<script>
+class eZSubitem extends Polymer.Element {
+    static get is() {
+        return 'ez-subitem';
+    }
+
+    static get properties() {
+        return {
+            "parentLocationId": {
+                type: String,
+            },
+        };
+    }
+
+    constructor() {
+        super();
+        console.log('ez-subitem constructor', arguments, this);
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._trackYUIAppReady();
+    }
+
+    _trackYUIAppReady() {
+        if ( eZ.YUI ) {
+            return this._createSubitemComponent();
+        }
+        document.addEventListener('ez:yui-app:ready', this._createSubitemComponent.bind(this));
+    }
+
+    _createSubitemComponent() {
+        const app = eZ.YUI.app;
+        const Y = eZ.YUI.Y;
+        const params = {
+            id: this.parentLocationId,
+            languageCode: 'eng-GB'
+        };
+
+        app.renderView(
+            Y.eZ.SubitemBoxView,
+            // LocationViewViewService works for SubitemBoxView but it does too
+            // many things for it, mainly it loads the path of the Location
+            // while it's not actually needed.
+            // Another reason to have an another view service would be to change
+            // the component to receive a Location id (not the REST id), so the
+            // view service would have to load the Location by this id.
+            Y.eZ.LocationViewViewService,
+            params,
+            this._attachView.bind(this)
+        );
+    }
+
+    _attachView(err, viewService, view) {
+        this.innerHTML = '';
+        if ( err ) {
+            this.innerHTML = 'An error occurred';
+            return;
+        }
+        this._view = view;
+        this._blockClick(view);
+        view.on('*:navigateTo', function (e) {
+            let event, view = e.target;
+
+            e.halt();
+            if ( e.route.name === 'viewLocation' && e.item ) {
+                event = new CustomEvent('browseToContent', {
+                    detail: {
+                        // getting a YUI free representation but it's most likely
+                        // still to tight to YUI Model/REST API
+                        // when using the UDW, we'll have the same problem,
+                        // at some point we'll have to add a proper conversion
+                        // from Models to ValueObject
+                        location: e.item.location.toJSON(),
+                        content: e.item.content.toJSON(),
+                    },
+                    bubbles: true,
+                });
+                this.dispatchEvent(event);
+            } else {
+                console.warn('Got a navigateTo event but no data to transform it', e);
+            }
+        }.bind(this));
+        this.appendChild(view.get('container').getDOMNode());
+        view.set('active', true);
+
+        // using the shadow DOM is another option. It allows to somehow
+        // hide the internal of the component but on the other hand
+        // it makes styling harder as we have to add the CSS in the component
+        // itself.
+        //let shadowRoot = this.attachShadow({mode: 'open'});
+        //shadowRoot.appendChild(view.get('container').getDOMNode());
+    }
+
+    _blockClick(view) {
+        view.get('container').delegate('click', function (e) {
+            e.halt(true);
+        }, 'a');
+    }
+
+    disconnectedCallback() {
+        if ( this._view ) {
+            this._view.set('active', false);
+            this._view.destroy({remove: true});
+        }
+        super.disconnectedCallback();
+    }
+}
+
+customElements.define(eZSubitem.is, eZSubitem);
+</script>

--- a/src/bundle/Resources/public/webcomponents/ez-toolbar.html
+++ b/src/bundle/Resources/public/webcomponents/ez-toolbar.html
@@ -1,0 +1,49 @@
+<link rel="import" href="../../../assets/ezplatform/polymer/polymer-element.html">
+
+<style>
+ez-toolbar {
+    display: none;
+}
+ez-toolbar[visible="false"] {
+    display: none;
+}
+ez-toolbar[visible="true"] {
+    display: block;
+}
+</style>
+
+<script>
+(function () {
+    class eZToolbar extends Polymer.Element {
+        static get is() {
+            return 'ez-toolbar';
+        }
+
+        static get properties() {
+            return {
+                "visible": {
+                    // handled as a string to avoid inconsistencies, so with that will get
+                    // visible="false" or visible="true" but not visible alone in the markup
+                    type: String,
+                    reflectToAttribute: true,
+                    value: "false",
+                },
+            };
+        }
+
+        constructor() {
+            super();
+        }
+
+        connectedCallback() {
+            super.connectedCallback();
+        }
+
+        disconnectedCallback() {
+            super.disconnectedCallback();
+        }
+    }
+
+    customElements.define(eZToolbar.is, eZToolbar);
+})();
+</script>

--- a/src/bundle/Resources/public/webcomponents/ez-universaldiscoverywidget.html
+++ b/src/bundle/Resources/public/webcomponents/ez-universaldiscoverywidget.html
@@ -1,0 +1,123 @@
+<link rel="import" href="../../../assets/ezplatform/polymer/polymer-element.html">
+<link rel="import" href="../../../webcomponents/ez-yui-app.html">
+
+<script>
+class eZUniversalDiscoveryWidget extends Polymer.Element {
+    static get is() {
+        return 'ez-universaldiscoverywidget';
+    }
+
+    static get properties() {
+        return {
+            "title": {
+                type: String,
+            },
+            "multiple": {
+                type: Boolean,
+                value: false,
+            },
+            "onconfirm": {
+                type: Function,
+                value: function () {},
+            },
+            "oncancel": {
+                type: Function,
+                value: function () {},
+            },
+            "is-selectable": {
+                type: Function,
+                value: () => true,
+            },
+            "starting-location-id": {
+                type: String,
+            },
+            // is-selectable is a bad name coming from 1.x. Also, onconfirm and
+            // oncancel are a bit misleading because this suggests there are
+            // confirm` and `cancel` events behind the scene while there's none.
+            // So maybe, the UDW should actually triggers real events
+            // (confirm, cancel, select) instead of exposing such attributes.
+        };
+    }
+
+    constructor() {
+        super();
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._trackYUIAppReady();
+    }
+
+    _trackYUIAppReady() {
+        if ( eZ.YUI ) {
+            return this._createUDWComponent();
+        }
+        document.addEventListener('ez:yui-app:ready', this._createUDWComponent.bind(this));
+    }
+
+    _convertItem(item) {
+        return {
+            content: item.content.toJSON(),
+            location: item.location.toJSON(),
+            contentType: item.contentType.toJSON(),
+        };
+    }
+
+    _convertSelection(selection) {
+        if ( this.multiple ) {
+            return selection.map(this._convertItem);
+        }
+        return this._convertItem(selection);
+    }
+
+    _createUDWComponent() {
+        const app = eZ.YUI.app;
+        const Y = eZ.YUI.Y;
+        const params = {
+            title: this.title,
+            multiple: this.multiple,
+            contentDiscoveredHandler: function (e) {
+                this.onconfirm.call(this, this._convertSelection(e.selection));
+            }.bind(this),
+            cancelDiscoverHandler: this.oncancel,
+            startingLocationId: this.startingLocationId,
+        };
+
+        if ( this.isSelectable ) {
+            params.isSelectable = function (item) {
+                return this.isSelectable.call(this, this._convertItem(item));
+            }.bind(this);
+        }
+
+        app.renderSideView(
+            Y.eZ.UniversalDiscoveryView,
+            Y.eZ.UniversalDiscoveryViewService,
+            params,
+            this._attachView.bind(this)
+        );
+    }
+
+    _attachView(err, viewService, view) {
+        this.innerHTML = '';
+        if ( err ) {
+            this.innerHTML = 'An error occurred';
+            return;
+        }
+        this.appendChild(view.get('container').getDOMNode());
+        view.set('active', true);
+
+        // using the shadow DOM is another option. It allows to somehow
+        // hide the internal of the component but on the other hand
+        // it makes styling harder as we have to add the CSS in the component
+        // itself.
+        //let shadowRoot = this.attachShadow({mode: 'open'});
+        //shadowRoot.appendChild(view.get('container').getDOMNode());
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+    }
+}
+
+customElements.define(eZUniversalDiscoveryWidget.is, eZUniversalDiscoveryWidget);
+</script>

--- a/src/bundle/Resources/views/components/app.html.twig
+++ b/src/bundle/Resources/views/components/app.html.twig
@@ -1,0 +1,27 @@
+{% extends "@EzSystemsHybridPlatformUi/layout.html.twig" %}
+
+{% block app %}
+
+<{{ tagName }}>
+
+    {% block navigationHub %}
+        {{ navigationHub|raw }}
+    {% endblock %}
+
+    {% block main %}
+        <main>
+            {% block toolbars %}
+                {% for toolbar in toolbars %}
+                    {{ toolbar|raw }}
+                {% endfor %}
+            {% endblock %}
+
+            {% block mainContent %}
+                {{ mainContent|raw }}
+            {% endblock %}
+        </main>
+    {% endblock %}
+
+</{{ tagName }}>
+
+{% endblock %}

--- a/src/bundle/Resources/views/components/navigationhub.html.twig
+++ b/src/bundle/Resources/views/components/navigationhub.html.twig
@@ -1,0 +1,21 @@
+<{{ tag }}{% for name, value in attributes %} {{ name }}="{{ value }}"{% endfor %}>
+    <a href="{{ path( 'ez_hybrid_platform_ui_dashboard' ) }}"><img src="{{ asset( 'bundles/ezplatformui/img/logo.png' ) }}" alt="eZ Platform logo"></a>
+    <ul class="ez-zone-list">
+    {% for zone in zones %}
+    <li{% if activeZone == zone.identifier %} class="{{ activeZoneClass }}"{% endif %} data-zone-identifier="{{ zone.identifier }}">
+        <a href="#">{{ zone.name }}</a>
+    </li>
+    {% endfor %}
+    </ul>
+    <nav>
+        <ul class="ez-navigation">
+        {% for link in links %}
+        <li data-zone="{{ link.zone }}"
+            {% if link.match(app.request) %}class="{{ matchedLinkClass }}"{% endif %}
+            {% if link.zone != activeZone %}style="display: none;"{% endif %}>
+            <a href="{{ link.url }}">{{ link.name }}</a>
+        </li>
+        {% endfor %}
+        </ul>
+    </nav>
+</{{ tag }}>

--- a/src/bundle/Resources/views/dashboard.html.twig
+++ b/src/bundle/Resources/views/dashboard.html.twig
@@ -1,0 +1,1 @@
+<h1>Dashboard</h1>

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -1,0 +1,70 @@
+<!doctype html>
+<html class=""><!-- empty class is needed for webcomponents polyfill with ez-yui-app.html import (?!) -->
+<head>
+    <title>{{ title|default("AdminUI prototype") }}</title>
+    <meta name="viewport" content="width=device-width">
+    <meta charset="utf-8">
+
+{% stylesheets '$css.files;ez_platformui$' filter='cssrewrite' %}
+    <link rel="stylesheet" href="{{ asset_url }}"/>
+{% endstylesheets %}
+
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+        a, a:visited {
+            color: #009;
+        }
+        body {
+            display: flex;
+            flex-direction: column;
+            margin: 0;
+        }
+        ez-navigation-hub {
+            border: 2px solid green;
+            flex: 0 0 8em;
+        }
+        main {
+            border: 2px solid red;
+            min-height: calc(100vh - 8em);
+            flex: 1 0;
+            display: flex;
+        }
+        ez-toolbar {
+            border: 2px solid blue;
+            flex: 0 0 230px;
+        }
+        ez-toolbar > * {
+            line-height: 3;
+            border: 1px solid purple;
+        }
+        ez-browse:after {
+            content: " (" attr(location-id) ")";
+        }
+        ez-main-content {
+            flex: 1 1;
+        }
+        ez-subitem {
+            border: 1px solid aqua;
+        }
+    </style>
+
+    <script src="{{ asset('assets/ezplatform/webcomponentsjs/webcomponents-lite.js') }}"></script>
+    <script src="{{ asset('bundles/fosjsrouting/js/router.js') }}"></script>
+    <script src="{{ path('fos_js_routing_js', { callback: 'fos.Router.setData' }) }}"></script>
+
+    <link rel="import" href="{{ asset( 'bundles/ezsystemshybridplatformui/webcomponents/ez-platformui-app.html' ) }}">
+    <link rel="import" href="{{ asset( 'bundles/ezsystemshybridplatformui/webcomponents/ez-navigation-hub.html' ) }}">
+    <link rel="import" href="{{ asset( 'bundles/ezsystemshybridplatformui/webcomponents/ez-toolbar.html' ) }}">
+    <link rel="import" href="{{ asset( 'bundles/ezsystemshybridplatformui/webcomponents/ez-main-content.html' ) }}">
+    <link rel="import" href="{{ asset( 'bundles/ezsystemshybridplatformui/webcomponents/ez-browse.html' ) }}">
+
+    <link rel="import" href="{{ asset( 'bundles/ezplatformui/webcomponents/ez-subitem.html' ) }}">
+    <link rel="import" href="{{ asset( 'bundles/ezplatformui/webcomponents/ez-universaldiscoverywidget.html' ) }}">
+</head>
+<body class="ez-platformui-app is-app-open">
+    {% block app %}
+    {% endblock %}
+</body>
+</html>

--- a/src/bundle/Resources/views/locationview.html.twig
+++ b/src/bundle/Resources/views/locationview.html.twig
@@ -1,0 +1,15 @@
+<h1>{{ location.contentInfo.name }} (Location #{{ location.id }})</h1>
+
+{% for field in content.fieldsByLanguage(language|default(null)) %}
+    <h3>{{ field.fieldDefIdentifier }}</h3>
+    {{ ez_render_field(content, field.fieldDefIdentifier) }}
+{% endfor %}
+
+{# using the REST id Location for now to not have to find a cheap and easy way
+ # to get the REST id for the regular Location id, but at the some point, this will
+ # have to be changed. This involves developping a new view service.
+ # see app.renderView() call in WebComponent/ez-subitem.html.twig
+ #}
+<ez-subitem parent-location-id="{{ path( 'ezpublish_rest_loadLocation', {'locationPath': location.pathString|trim('/')} ) }}">
+    Loading subitems...
+</ez-subitem>

--- a/src/lib/App/AppResponseRenderer.php
+++ b/src/lib/App/AppResponseRenderer.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUi\App;
+
+use EzSystems\HybridPlatformUi\Components\App;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Renders an App into a Response.
+ */
+interface AppResponseRenderer
+{
+    /**
+     * Renders $app, and sets the result into the given $response.
+     *
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     * @param \EzSystems\HybridPlatformUi\Components\App $app
+     *
+     * @return void
+     */
+    public function render(Response $response, App $app);
+}

--- a/src/lib/App/RequestAppResponseRenderer.php
+++ b/src/lib/App/RequestAppResponseRenderer.php
@@ -36,6 +36,7 @@ class RequestAppResponseRenderer implements AppResponseRenderer
     public function render(Response $response, App $app)
     {
         $app->setConfig(['mainContent' => ['result' => $response->getContent()]]);
+        $this->configureToolbars($app);
 
         $appResponse = $this->ajaxUpdateRequestMatcher->matches($this->request)
             ? new JsonResponse($app)
@@ -44,5 +45,15 @@ class RequestAppResponseRenderer implements AppResponseRenderer
         $response
             ->setContent($appResponse->getContent())
             ->headers->replace($appResponse->headers->all());
+    }
+
+    /**
+     * Configures the toolbars.
+     *
+     * @todo Depends on the Request. Must be triggered by another event.
+     */
+    private function configureToolbars(App $app)
+    {
+        $app->setConfig(['toolbars' => ['discovery' => 1]]);
     }
 }

--- a/src/lib/App/RequestAppResponseRenderer.php
+++ b/src/lib/App/RequestAppResponseRenderer.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUi\App;
+
+use EzSystems\HybridPlatformUi\Components\App;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequestAppResponseRenderer implements AppResponseRenderer
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\Request
+     */
+    private $request;
+
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestMatcherInterface
+     */
+    private $ajaxUpdateRequestMatcher;
+
+    public function __construct(
+        Request $request,
+        RequestMatcherInterface $ajaxUpdateRequestMatcher
+    ) {
+        $this->request = $request;
+        $this->ajaxUpdateRequestMatcher = $ajaxUpdateRequestMatcher;
+    }
+
+    public function render(Response $response, App $app)
+    {
+        $app->setConfig(['mainContent' => ['result' => $response->getContent()]]);
+
+        $appResponse = $this->ajaxUpdateRequestMatcher->matches($this->request)
+            ? new JsonResponse($app)
+            : new Response($app);
+
+        $response
+            ->setContent($appResponse->getContent())
+            ->headers->replace($appResponse->headers->all());
+    }
+}

--- a/src/lib/Components/App.php
+++ b/src/lib/Components/App.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+use Symfony\Component\HttpFoundation\Request;
+use EzSystems\HybridPlatformUi\Components\Component;
+use EzSystems\HybridPlatformUi\Components\NavigationHub;
+use EzSystems\HybridPlatformUi\Components\MainContent;
+
+class App implements Component
+{
+    const TAG_NAME = 'ez-platformui-app';
+
+    protected $mainContent;
+
+    protected $navigationHub;
+
+    protected $toolbars;
+
+    protected $templating;
+
+    protected $title;
+
+    public function __construct(
+        $templating,
+        MainContent $content,
+        NavigationHub $navigationHub,
+        array $toolbars
+    ) {
+        $this->templating = $templating;
+        $this->mainContent = $content;
+        $this->navigationHub = $navigationHub;
+        $this->toolbars = $toolbars;
+    }
+
+    public function setConfig(array $config)
+    {
+        if (isset($config['title'])) {
+            $this->title = $config['title'];
+        }
+        if (isset($config['toolbars'])) {
+            $this->setToolbarsVisibility($config['toolbars']);
+        }
+
+        if (isset($config['mainContent']) && $config['mainContent'] instanceof Component) {
+            $this->mainContent = $config['mainContent'];
+        } elseif (isset($config['mainContent']['result'])) {
+            $this->mainContent->setResult($config['mainContent']['result']);
+        } elseif (isset($config['mainContent']) && is_array($config['mainContent'])) {
+            $this->mainContent->setTemplate($config['mainContent']['template']);
+            $this->mainContent->setParameters($config['mainContent']['parameters']);
+        }
+    }
+
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    protected function setToolbarsVisibility($config)
+    {
+        foreach ($this->toolbars as $toolbar) {
+            $toolbar->setVisible((bool)$config[$toolbar->getId()]);
+        }
+    }
+
+    public function __toString()
+    {
+        return $this->templating->render(
+            'EzSystemsHybridPlatformUiBundle:components:app.html.twig',
+            [
+                'tagName' => self::TAG_NAME,
+                'navigationHub' => $this->navigationHub,
+                'toolbars' => $this->toolbars,
+                'mainContent' => $this->mainContent,
+                'appTagName' => self::TAG_NAME,
+            ]
+        );
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'selector' => self::TAG_NAME,
+            'update' => [
+                'attributes' => [
+                    'title' => $this->title,
+                    'url' => $_SERVER['REQUEST_URI'],
+                ],
+                'children' => array_merge(
+                    $this->toolbars,
+                    [$this->navigationHub, $this->mainContent]
+                ),
+            ]
+        ];
+    }
+}

--- a/src/lib/Components/Browse.php
+++ b/src/lib/Components/Browse.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+class Browse implements Component
+{
+    protected $urlGenerator;
+
+    /**
+     * @var \Symfony\Component\HttpFoundation\Request
+     */
+    protected $request;
+
+    // passing the router is needed because at the moment the UDW only supports
+    // a REST Location id as the starting Location id, so this id is build there
+    public function __construct(Request $request, UrlGeneratorInterface $urlGenerator)
+    {
+        $this->request = $request;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    protected function getLocationId()
+    {
+        if ($this->request->attributes->get('location')) {
+            return $this->request->attributes->get('location')->id;
+        }
+        return "false";
+    }
+
+    protected function getLocationRestId()
+    {
+        if ($this->request->attributes->get('location')) {
+            return $this->urlGenerator->generate(
+                'ezpublish_rest_loadLocation',
+                ['locationPath' => trim($this->request->attributes->get('location')->pathString, '/')]
+            );
+        }
+        return "false";
+    }
+
+    public function __toString()
+    {
+        $selected = $this->getLocationRestId();
+        $id = $this->getLocationId();
+        // could be rendered with a twig template
+        return '<ez-browse selected-location-id="' . $selected . '" location-id="' . $id . '">Browse</ez-browse>';
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'selector' => 'ez-browse',
+            'update' => [
+                'attributes' => [
+                    'selected-location-id' => $this->getLocationRestId(),
+                    'location-id' => $this->getLocationId(),
+                ],
+            ],
+        ];
+    }
+}

--- a/src/lib/Components/Component.php
+++ b/src/lib/Components/Component.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+interface Component extends \JsonSerializable
+{
+    public function __toString();
+}

--- a/src/lib/Components/MainContent.php
+++ b/src/lib/Components/MainContent.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+// TODO find a better name
+class MainContent implements Component
+{
+    const TAG_NAME = 'ez-main-content';
+
+    protected $templating;
+
+    protected $template = null;
+
+    protected $parameters = [];
+
+    protected $result = false;
+
+    public function __construct($templating)
+    {
+        $this->templating = $templating;
+    }
+
+    public function setTemplate($template)
+    {
+        $this->template = $template;
+    }
+
+    public function setParameters($parameters)
+    {
+        $this->parameters = $parameters;
+    }
+
+    public function setResult($result)
+    {
+        $this->result = $result;
+    }
+
+    public function __toString()
+    {
+        $str = '<' . self::TAG_NAME . '>';
+        if ($this->result) {
+            $str .= $this->result;
+        } elseif ($this->template) {
+            $str .= $this->templating->render(
+                $this->template,
+                $this->parameters
+            );
+        }
+        $str .= '</' . self::TAG_NAME . '>';
+
+        return $str;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'selector' => self::TAG_NAME,
+            'update' => (string)$this,
+        ];
+    }
+}

--- a/src/lib/Components/NavigationHub.php
+++ b/src/lib/Components/NavigationHub.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class NavigationHub implements Component
+{
+    const TAG_NAME = 'ez-navigation-hub';
+
+    const ACTIVE_ZONE_CLASS = 'ez-active-zone';
+
+    const MATCHED_LINK_CLASS = 'ez-matched-link';
+
+    /**
+     * @var \Twig_Environment
+     */
+    protected $templating;
+
+    /**
+     * @var \EzSystems\HybridPlatformUi\NavigationHub\Zone[]
+     */
+    protected $zones;
+
+    /**
+     * @var \EzSystems\HybridPlatformUi\NavigationHub\Link[]
+     */
+    protected $links;
+
+    /**
+     * @var \Symfony\Component\HttpFoundation\Request
+     */
+    protected $request;
+
+    public function __construct($templating, Request $request, array $zones = [], array $links = [])
+    {
+        $this->request = $request;
+        $this->templating = $templating;
+        $this->zones = $zones;
+        $this->links = $links;
+    }
+
+    public function __toString()
+    {
+        return $this->templating->render(
+            'EzSystemsHybridPlatformUiBundle:components:navigationhub.html.twig',
+            [
+                'tag' => self::TAG_NAME,
+                'attributes' => $this->getAttributes(),
+                'zones' => $this->zones,
+                'links' => $this->links,
+                'activeZone' => $this->getActiveZoneIdentifier(),
+                'activeZoneClass' => self::ACTIVE_ZONE_CLASS,
+                'matchedLinkClass' => self::MATCHED_LINK_CLASS,
+            ]
+        );
+    }
+
+    protected function getActiveLink()
+    {
+        foreach ($this->links as $link) {
+            if ($link->match($this->request)) {
+                return $link;
+            }
+        }
+
+        return null;
+    }
+
+    protected function getActiveZoneIdentifier()
+    {
+        $link = $this->getActiveLink();
+        if ($link) {
+            return $link->zone;
+        }
+        return '';
+    }
+
+    protected function getActiveLinkUrl()
+    {
+        $link = $this->getActiveLink();
+
+        if ($link) {
+            return $link->getUrl();
+        }
+        return '';
+    }
+
+    protected function getAttributes()
+    {
+        return [
+            'active-zone-class' => self::ACTIVE_ZONE_CLASS,
+            'matched-link-class' => self::MATCHED_LINK_CLASS,
+            'active-zone' => $this->getActiveZoneIdentifier(),
+            'matched-link-url' => $this->getActiveLinkUrl(),
+        ];
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'selector' => self::TAG_NAME,
+            'update' => [
+                'attributes' => $this->getAttributes(),
+            ]
+        ];
+    }
+}

--- a/src/lib/Components/Search.php
+++ b/src/lib/Components/Search.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+class Search implements Component
+{
+    public function __toString()
+    {
+        return '<div>Dumb thing, never updated</div>';
+    }
+
+    public function jsonSerialize()
+    {
+        return false;
+    }
+}

--- a/src/lib/Components/Toolbar.php
+++ b/src/lib/Components/Toolbar.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+class Toolbar implements Component
+{
+    protected $children;
+
+    protected $id;
+
+    protected $visible;
+
+    public function __construct($id, array $children)
+    {
+        $this->id = $id;
+        $this->children = $children;
+    }
+
+    protected function getVisibleValue()
+    {
+        return $this->visible ? 'true' : 'false';
+    }
+
+    public function __toString()
+    {
+        $html = '<ez-toolbar id="' . $this->id . '" visible="' . $this->getVisibleValue() . '">';
+        foreach ($this->children as $component) {
+            $html .= (string)$component;
+        }
+        $html .= '</ez-toolbar>';
+
+        return $html;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setVisible($visible)
+    {
+        $this->visible = $visible;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'selector' => '#' . $this->id,
+            'update' => [
+                'attributes' => [
+                    'visible' => $this->getVisibleValue(),
+                ],
+                'children' => $this->children,
+            ],
+        ];
+    }
+}

--- a/src/lib/Components/Trash.php
+++ b/src/lib/Components/Trash.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Components;
+
+class Trash implements Component
+{
+    public function __toString()
+    {
+        return '<div class="ez-trash-button">Server side updated at <b>' . date('H:i:s') . '</b></div>';
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'selector' => '.ez-trash-button',
+            'update' => (string)$this,
+        ];
+    }
+}

--- a/src/lib/EventSubscriber/AppRendererSubscriber.php
+++ b/src/lib/EventSubscriber/AppRendererSubscriber.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\EventSubscriber;
+
+use EzSystems\HybridPlatformUi\App\AppResponseRenderer;
+use EzSystems\HybridPlatformUi\Components\App;
+use EzSystems\HybridPlatformUi\Components\Component;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class AppRendererSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestMatcherInterface
+     */
+    private $hybridRequestMatcher;
+
+    /**
+     * @var \EzSystems\HybridPlatformUi\Components\App
+     */
+    private $app;
+
+    /**
+     * @var \EzSystems\HybridPlatformUi\App\AppResponseRenderer
+     */
+    private $appRenderer;
+
+    public function __construct(
+        App $app,
+        AppResponseRenderer $appRenderer,
+        RequestMatcherInterface $hybridRequestMatcher
+    ) {
+        $this->hybridRequestMatcher = $hybridRequestMatcher;
+        $this->app = $app;
+        $this->appRenderer = $appRenderer;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::RESPONSE => ['renderApp', 5]];
+    }
+
+    public function renderApp(FilterResponseEvent $event)
+    {
+        if ($event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!$this->hybridRequestMatcher->matches($request)) {
+            return;
+        }
+
+        $this->appRenderer->render($event->getResponse(), $this->app);
+    }
+}

--- a/src/lib/EventSubscriber/ComponentRendererSubscriber.php
+++ b/src/lib/EventSubscriber/ComponentRendererSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\EventSubscriber;
+
+use EzSystems\HybridPlatformUi\Components\Component;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ComponentRendererSubscriber implements EventSubscriberInterface
+{
+    private $ajaxUpdateRequestMatcher;
+
+    public function __construct(RequestMatcherInterface $ajaxUpdateRequestMatcher)
+    {
+        $this->ajaxUpdateRequestMatcher = $ajaxUpdateRequestMatcher;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::VIEW => ['renderComponent']];
+    }
+
+    public function renderComponent(GetResponseForControllerResultEvent $event)
+    {
+        if (!($component = $event->getControllerResult()) instanceof Component) {
+            return;
+        }
+
+        $response = $this->ajaxUpdateRequestMatcher->matches($event->getRequest()) ?
+            new JsonResponse($component) :
+            new Response($component);
+
+        $event->setResponse($response);
+    }
+}

--- a/src/lib/EventSubscriber/CoreViewSubscriber.php
+++ b/src/lib/EventSubscriber/CoreViewSubscriber.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\EventSubscriber;
+
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\HybridPlatformUi\Mapper\MainContentMapper;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Remaps an EzPublishCore controller view admin requests to a MainComponent.
+ */
+class CoreViewSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestMatcherInterface
+     */
+    private $adminRequestMatcher;
+
+    /**
+     * @var \EzSystems\HybridPlatformUi\Mapper\MainContentMapper
+     */
+    private $mapper;
+
+    public function __construct(
+        MainContentMapper $coreViewMapper,
+        RequestMatcherInterface $adminRequestMatcher
+    ) {
+        $this->mapper = $coreViewMapper;
+        $this->adminRequestMatcher = $adminRequestMatcher;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::VIEW => ['mapAdminViewToMainComponent', 10]];
+    }
+
+    public function mapAdminViewToMainComponent(GetResponseForControllerResultEvent $event)
+    {
+        if (!$this->adminRequestMatcher->matches($event->getRequest())) {
+            return;
+        }
+
+        if (!($view = $event->getControllerResult()) instanceof View) {
+            return;
+        }
+
+        $event->setControllerResult($this->mapper->map($view));
+    }
+}

--- a/src/lib/Http/AjaxUpdateRequestMatcher.php
+++ b/src/lib/Http/AjaxUpdateRequestMatcher.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Http;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+class AjaxUpdateRequestMatcher implements RequestMatcherInterface
+{
+    public function matches(Request $request)
+    {
+        return $request->headers->has('x-ajax-update');
+    }
+}

--- a/src/lib/Http/ChainRequestMatcher.php
+++ b/src/lib/Http/ChainRequestMatcher.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Http;
+
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class ChainRequestMatcher implements RequestMatcherInterface
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestMatcherInterface[]
+     */
+    private $requestMatchers;
+
+    public function __construct(RequestMatcherInterface...$requestMatchers)
+    {
+        $this->requestMatchers = $requestMatchers;
+    }
+
+    public function matches(Request $request)
+    {
+        foreach ($this->requestMatchers as $requestMatcher) {
+            if (!$requestMatcher->matches($request)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/lib/Http/HardcodedAdminRequestMatcher.php
+++ b/src/lib/Http/HardcodedAdminRequestMatcher.php
@@ -7,9 +7,32 @@ use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 
 class HardcodedAdminRequestMatcher implements RequestMatcherInterface
 {
+    /**
+     * @var array
+     */
+    private $excludedRoutes = [];
+
+    /**
+     * @param array $routes
+     */
+    public function setExcludedRoutesPrefixes($routes)
+    {
+        $this->excludedRoutes = $routes;
+    }
+
     public function matches(Request $request)
     {
-        // @todo can't be hardcoded
-        return strpos($request->getRequestUri(), '/admin') === 0;
+        if (strpos($request->getRequestUri(), '/admin') !== 0) {
+            return false;
+        }
+
+        $routeName = $request->attributes->get('_route');
+        foreach ($this->excludedRoutes as $prefix) {
+            if (strpos($routeName, $prefix) === 0) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/lib/Http/HardcodedAdminRequestMatcher.php
+++ b/src/lib/Http/HardcodedAdminRequestMatcher.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Http;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+
+class HardcodedAdminRequestMatcher implements RequestMatcherInterface
+{
+    public function matches(Request $request)
+    {
+        // @todo can't be hardcoded
+        return strpos($request->getRequestUri(), '/admin') === 0;
+    }
+}

--- a/src/lib/Http/HtmlFormatRequestMatcher.php
+++ b/src/lib/Http/HtmlFormatRequestMatcher.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Http;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher;
+
+class HtmlFormatRequestMatcher extends RequestMatcher
+{
+    public function __construct()
+    {
+        parent::__construct(null, null, null, null, ['_format' => '^(?!js).*$']);
+    }
+    public function match(Request $request)
+    {
+        return parent::matches($request);
+    }
+}

--- a/src/lib/Mapper/MainContentMapper.php
+++ b/src/lib/Mapper/MainContentMapper.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUi\Mapper;
+
+use EzSystems\PlatformUIBundle\Components\MainContent;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Maps an object to a MainComponent.
+ */
+interface MainContentMapper
+{
+    /**
+     * @param mixed $value
+     *
+     * @return \EzSystems\HybridPlatformUi\Components\MainContent
+     */
+    public function map($value);
+}

--- a/src/lib/NavigationHub/Link.php
+++ b/src/lib/NavigationHub/Link.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\NavigationHub;
+
+use Symfony\Component\HttpFoundation\Request;
+
+abstract class Link
+{
+    public $zone;
+
+    public $name;
+
+    abstract public function match(Request $request);
+}

--- a/src/lib/NavigationHub/Link/Route.php
+++ b/src/lib/NavigationHub/Link/Route.php
@@ -1,0 +1,67 @@
+<?php
+namespace EzSystems\HybridPlatformUi\NavigationHub\Link;
+
+use EzSystems\HybridPlatformUi\NavigationHub\Link;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class Route extends Link
+{
+    /**
+     * @var \Symfony\Component\Routing\Generator\UrlGeneratorInterface
+     */
+    protected $urlGenerator;
+
+    /**
+     * @var string
+     */
+    protected $routeName;
+
+    /**
+     * @var string
+     */
+    protected $routeParams;
+
+    public function __construct(UrlGeneratorInterface $urlGenerator, $routeName, $routeParams, $name, $zoneIdentifier)
+    {
+        $this->urlGenerator = $urlGenerator;
+        $this->zone = $zoneIdentifier;
+        $this->name = $name;
+        $this->routeName = $routeName;
+        $this->routeParams = $routeParams;
+    }
+
+    public function getUrl()
+    {
+        return $this->urlGenerator->generate($this->routeName, $this->routeParams);
+    }
+
+    public function match(Request $request)
+    {
+        $routeName = $request->attributes->get('_route');
+        $routeParams = $request->attributes->get('_routeParams', []);
+
+        return (
+            $this->matchRoute($routeName)
+            && $this->matchRouteParams($routeParams)
+        );
+    }
+
+    protected function matchRoute($routeName)
+    {
+        return $routeName === $this->routeName;
+    }
+
+    protected function matchRouteParams($params)
+    {
+        if (count($params) !== count($this->routeParams)) {
+            return false;
+        }
+        foreach ($params as $name => $value) {
+            if (!isset($this->routeParams[$name]) || $this->routeParams[$name] !== $value) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/lib/NavigationHub/Link/Subtree.php
+++ b/src/lib/NavigationHub/Link/Subtree.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\NavigationHub\Link;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class Subtree extends Route
+{
+    public function match(Request $request)
+    {
+        $location = $request->attributes->get('location');
+
+        return
+            $this->matchRoute($this->routeName)
+            && $location
+            && in_array((string)$this->routeParams['locationId'], $location->path)
+        ;
+    }
+}

--- a/src/lib/NavigationHub/Zone.php
+++ b/src/lib/NavigationHub/Zone.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\NavigationHub;
+
+class Zone
+{
+    public $name;
+
+    public $identifier;
+
+    public function __construct($name, $identifier)
+    {
+        $this->name = $name;
+        $this->identifier = $identifier;
+    }
+}

--- a/src/lib/Platform/AdminSiteAccessConfigurationFilter.php
+++ b/src/lib/Platform/AdminSiteAccessConfigurationFilter.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUi\Platform;
+
+use eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessConfigurationFilter;
+
+class AdminSiteAccessConfigurationFilter implements SiteAccessConfigurationFilter
+{
+    public function filter(array $configuration)
+    {
+        $multiSite = count($configuration['groups']) > 1;
+        $updatedConfiguration = $configuration;
+        $updatedConfiguration['groups']['admin_group'] = [];
+
+        foreach (array_keys($configuration['groups']) as $groupName) {
+            $adminSiteAccessName = $multiSite
+                ? str_replace('_group', '', $groupName) . '_admin'
+                : 'admin';
+            $updatedConfiguration['list'][] = $adminSiteAccessName;
+            $updatedConfiguration['groups'][$groupName][] = $adminSiteAccessName;
+            $updatedConfiguration['groups']['admin_group'][] = $adminSiteAccessName;
+        }
+
+        return $updatedConfiguration;
+    }
+}

--- a/src/lib/View/CoreViewMainContentMapper.php
+++ b/src/lib/View/CoreViewMainContentMapper.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUi\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\HybridPlatformUi\Components\MainContent;
+use EzSystems\HybridPlatformUi\Mapper\MainContentMapper;
+
+class CoreViewMainContentMapper implements MainContentMapper
+{
+    /**
+     * @var MainContent
+     */
+    private $mainContent;
+
+    public function __construct(MainContent $mainContent)
+    {
+        $this->mainContent = $mainContent;
+    }
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\View\View $view
+     *
+     * @return \EzSystems\HybridPlatformUi\Components\MainContent
+     */
+    public function map($view)
+    {
+        if (!$view instanceof View) {
+            throw new \InvalidArgumentException('Expected an \eZ\Publish\Core\MVC\Symfony\View\View');
+        }
+
+        $this->mainContent->setTemplate($view->getTemplateIdentifier());
+        $this->mainContent->setParameters($view->getParameters());
+
+        return $this->mainContent;
+    }
+}


### PR DESCRIPTION
> [EZP-27158](http://jira.ez.no/browse/EZP-27158)
> Related pull-requests: ezsystems/ezplatform#177, ezsystems/ezpublish-kernel#1977, ezsystems/PlatformUIBundle#855)

### Abstract
This is the cleaned-up integration of the hybrid application prototypes. It includes:

- Hybrid app/component architecture. Partial updates are obtained from the server, providing a fast-responding UI while based on standard Symfony Framework features.
- Navigation hub from YUI
- Toolbars skeleton
- Location view skeleton, with sub-items list from YUI
- Dashboard skeleton

![capture d ecran 2017-05-02 a 11 24 47](https://cloud.githubusercontent.com/assets/235928/25612324/7af038ce-2f2a-11e7-9562-4a64533d1495.png)

### Testing instructions
Checkout the [hybrid_ui_integration](https://github.com/ezsystems/ezplatform/pull/177) branch, and run composer update. Note: it checks out a 2.0 ezplatform version, with major updates of the kernel and platform-ui.

Visit http://<host>/admin.

### TODO
- [x] Fix the js routing request. It gets wrapped into the HTML structure, and makes absolutely no sense.
- [x] Make sure that the package can be installed on top of ezplatform @ master.
- [x] Add a proper description, instructions ~~and a screenshot~~
- [x] Get Travis to pass
- [x] Fix phpspec (admin request matcher)
- [ ] Create follow-ups. Non-exhaustive list:
  - Improved admin siteaccess handling ([EZP-27115](https://jira.ez.no/browse/EZP-27115))
  - Toolbars configuration ([EZP-27322](https://jira.ez.no/browse/EZP-27322), #4)
  - PJAX integration ([EZP-27282](https://jira.ez.no/browse/EZP-27282), #3)
  - Proper rendering of Components
  - Fix navigation hub toggling of links that require specific permissions
  - Proper authentication integration
  - Content editing
  - Content viewing ?