### PR TITLE
Pjax integration

### DIFF
--- a/docs/howto/add_navigation_hub_items.md
+++ b/docs/howto/add_navigation_hub_items.md
@@ -1,0 +1,116 @@
+# How-to: add items to the navigation hub
+
+The navigation hub, that shows zones and links in the UI, can easily be added items
+by means of tagged services.
+
+## Adding a zone item
+Zones contain a set of links. The default zones are Content, Page, Performances and Admin.
+A new zone would for instance be added by a 3rd party bundle to integrate some kind of application
+in the backoffice, with several sub-chapters. 
+
+A zone is visible when one of its links is visible for the current page.
+
+To define a new zone, create a new service tagged with the `ezplatform.ui.zone` service tag,
+using the `EzSystems\HybridPlatformUi\NavigationHub\Zone` class (or a subclass of it). You
+may use`"%ezsystems.platformui.navigationhub.zone.class%"` instead of the class.
+
+```yaml
+service:
+    my_bundle.platform_ui_navigationhub.zones.my_feature:
+        class: "%ezsystems.platformui.navigationhub.zone.class%"
+        # Recommended as we don't intend to get this service from the container
+        public: false
+        arguments:
+            - "My feature"
+            - "my_feature"
+        tags:
+            - {name: ezplatform.ui.zone}
+``` 
+
+|Argument|Description|
+|--------|-----------|
+|name|The human readable name of the zone, as displayed in the UI|
+|identifier|The zone's identifier, a simple string. It will be used when defining links to refer to the zone|
+
+Once the service has been defined, the new Zone should show up in the UI after refreshing.
+
+## Adding links to a zone
+Any number of links (within reason, it should fit a typical UI user screen) can be added to a zone.
+
+Links can be added to any zone, defined by your code or not. A minor feature, identified as a subset of an existing
+zone, such as Content, should be added to existing zones. Links that are part of a larger feature that defines its
+own zone should be added there.
+
+A Link is responsible for:
+- Generating urls to any URI
+- Saying which zone it should show up for
+- Saying if it is active for a given request
+
+To define a new link, create a service tagged with the `ezplatform.ui.link` service tag,
+using the `EzSystems\HybridPlatformUi\NavigationHub\Link` class or one of its subclasses.
+Several Links types are built-in, and new ones can be implemented.
+
+### Subtree links
+A subtree link uses the router and a location id. It will toggle
+when browsing and operating inside that location's subtree (included).
+
+```yaml
+services:
+    my_bundle.platform_ui_navigationhub.link.contentstructure:
+        class: "%ezsystems.platformui.navigationhub.link.subtree.class%"
+        arguments:
+            - "@router"
+            - "Blog"
+            - "content"
+            - 123
+        tags:
+            - {name: ezplatform.ui.link}
+        public: false
+```    
+
+|Argument|Description|
+|--------|-----------|
+|`router`|The router service (`@router`)|
+|`name`|The human readable name of the link, as displayed in the UI|
+|`zoneIdentifier`|The zone this links should be visible for. In the example above, the link is visible inside the "content" zone|
+|`location`|The parameters used to load the Location. The key indicates the parameter. Possible keys: `locationId`|
+
+### Route links
+A route link will link to any defined route, with any given set of parameters.
+These links will be used to link directly to any feature in the system.
+
+The link will match the same route and parameters exactly. An optional parameter allows
+it to match a given route prefix, in order to toggle the link for all the parts that
+belong to it (example: "Section" in the admin toggles on the section list, edit or view pages).
+
+The following service defines the section link in the admin zone:
+
+```yaml
+services:
+    ezsystems.platformui.navigationhub.link.admin.dashboard:
+        class: "%ezsystems.platformui.navigationhub.link.route.class%"
+        arguments:
+            - "@router"
+            - "admin_sectionlist"
+            - "Sections"
+            - "admin"
+        calls:
+            # @todo implement the setter ;)
+            - [setRoutePrefix, ["admin_section"]]
+        tags:
+            - {name: ezplatform.ui.link}
+        public: false
+```    
+
+|Argument|Description|
+|--------|-----------|
+|`router`|The router service (`@router`)|
+|`name`|The human readable name of the link, as displayed in the UI|
+|`zoneIdentifier`|The zone this links should be visible for. In the example above, the link is visible inside the "admin" zone|
+|`route_name`|The route used to generate the link and match requests|
+|`route_parameters`|An array of route parameters that will be used to generate the link and match requests|
+
+A setter method `setRoutePrefix` can be used to define a route prefix used to match requests.
+If given, a Request's route with the same prefix will match (example: `admin_sectionedit` matches the
+`admin_section` prefix).
+

--- a/spec/EventSubscriber/CoreViewSubscriberSpec.php
+++ b/spec/EventSubscriber/CoreViewSubscriberSpec.php
@@ -12,6 +12,7 @@ use stdClass;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -83,8 +84,8 @@ class CoreViewSubscriberSpec extends ObjectBehavior
     ) {
         $event->getControllerResult()->willReturn($view);
 
-        $mapper->map($view)->willReturn($mainContent);
-        $event->setControllerResult($mainContent)->shouldBeCalled();
+        $mapper->map($view)->shouldBeCalled();
+        $event->setResponse(Argument::type(Response::class))->shouldBeCalled();
 
         $this->mapAdminViewToMainComponent($event);
     }

--- a/spec/EventSubscriber/PjaxSubscriberSpec.php
+++ b/spec/EventSubscriber/PjaxSubscriberSpec.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\EventSubscriber;
+
+use EzSystems\HybridPlatformUi\Components\App;
+use EzSystems\HybridPlatformUi\Components\MainContent;
+use EzSystems\HybridPlatformUi\EventSubscriber\PjaxSubscriber;
+use EzSystems\HybridPlatformUi\Mapper\MainContentMapper;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class PjaxSubscriberSpec extends ObjectBehavior
+{
+    function let(
+        FilterResponseEvent $event,
+        MainContentMapper $mapper,
+        Request $request,
+        RequestMatcherInterface $adminRequestMatcher,
+        RequestMatcherInterface $pjaxRequestMatcher,
+        Response $response
+    ) {
+        $this->beConstructedWith($mapper, $adminRequestMatcher, $pjaxRequestMatcher);
+
+        $event->getRequest()->willReturn($request);
+        $event->getResponse()->willReturn($response);
+        $adminRequestMatcher->matches($request)->willReturn(true);
+        $pjaxRequestMatcher->matches($request)->willReturn(true);
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PjaxSubscriber::class);
+        $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    function it_ignores_sub_requests(FilterResponseEvent $event)
+    {
+        $event->getRequestType()->willReturn(HttpKernelInterface::SUB_REQUEST);
+        $event->getResponse()->shouldNotBeCalled();
+
+        $this->mapPjaxResponseToMainContent($event);
+    }
+
+    function it_ignores_non_admin_requests(
+        FilterResponseEvent $event,
+        Request $request,
+        RequestMatcherInterface $adminRequestMatcher
+    ) {
+        $adminRequestMatcher->matches($request)->willReturn(false);
+        $event->getResponse()->shouldNotBeCalled();
+
+        $this->mapPjaxResponseToMainContent($event);
+    }
+
+    function it_ignores_non_pjax_requests(
+        FilterResponseEvent $event,
+        Request $request,
+        RequestMatcherInterface $pjaxRequestMatcher
+    ) {
+        $pjaxRequestMatcher->matches($request)->willReturn(false);
+        $event->getResponse()->shouldNotBeCalled();
+
+        $this->mapPjaxResponseToMainContent($event);
+    }
+
+    function it_maps_pjax_redirect_responses_to_redirect_responses_using_the_pjax_location_response_header(
+        FilterResponseEvent $event,
+        RedirectResponse $redirectResponse
+    ) {
+        $event->getResponse()->willReturn($redirectResponse);
+        $event->setResponse(Argument::any())->shouldNotBeCalled();
+        $event->stopPropagation()->shouldBeCalled();
+
+        $this->mapPjaxResponseToMainContent($event);
+    }
+
+    function it_sets_the_app_maincontent_result_with_the_value_returned_by_the_mapper(
+        FilterResponseEvent $event,
+        MainContentMapper $mapper,
+        Response $response
+    ) {
+        $mapper->map($response)->shouldBeCalled();
+        $this->mapPjaxResponseToMainContent($event);
+    }
+}

--- a/spec/Pjax/PjaxResponseMainContentMapperSpec.php
+++ b/spec/Pjax/PjaxResponseMainContentMapperSpec.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\Pjax;
+
+use EzSystems\HybridPlatformUi\Components\App;
+use EzSystems\HybridPlatformUi\Pjax\PjaxResponseMainContentMapper;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\Response;
+
+class PjaxResponseMainContentMapperSpec extends ObjectBehavior
+{
+    function let(
+        App $app,
+        Response $response
+    ) {
+        $response->getContent()->willReturn(
+            file_get_contents(__DIR__ . '/_fixtures/pjax_response.html')
+        );
+
+        $this->beConstructedWith($app);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PjaxResponseMainContentMapper::class);
+    }
+
+    function it_maps_to_a_PjaxView(
+        App $app,
+        Response $response
+    ) {
+        $app->setConfig(Argument::any())->shouldBeCalled();
+
+        $this->map($response);
+    }
+
+    function it_parses_the_title_and_sets_it_as_the_app_title(
+        App $app,
+        Response $response
+    ) {
+        $app->setConfig(Argument::that(function ($value) {
+            return
+                is_array($value) &&
+                isset($value['title']) &&
+                $value['title'] === 'Response title';
+        }))->shouldBeCalled();
+
+        $this->map($response);
+    }
+
+    function it_parses_the_content_and_sets_it_as_the_app_MainContent_result(
+        App $app,
+        Response $response
+    ) {
+        $app->setConfig(Argument::that(function ($value) {
+            return
+                is_array($value) &&
+                isset($value['mainContent']) &&
+                isset($value['mainContent']['result']) &&
+                strpos($value['mainContent']['result'], 'Server side content') !== false;
+        }))->shouldBeCalled();
+
+        $this->map($response);
+    }
+
+    function getMatchers()
+    {
+        return [
+            'haveTitle' => function (App $app, $expectedTitle) {
+                return $mainContent->getTitle() == $expectedTitle;
+            },
+            'haveResult' => function (App $app, $expectedContent) {
+                return strstr((string)$mainContent, $expectedContent) !== null;
+            },
+        ];
+    }
+}

--- a/spec/Pjax/_fixtures/pjax_response.html
+++ b/spec/Pjax/_fixtures/pjax_response.html
@@ -1,0 +1,11 @@
+<div data-name="title">Response title</div>
+
+<div data-name="html">
+    <header class="ez-page-header">
+        <nav class="ez-breadcrumbs">breadcrumb</nav>
+        <h1 class="ez-page-header-name" data-icon="&#xe91f;">Header</h1>
+    </header>
+    <section class="extra-class ez-serverside-content">Server side content</section>
+</div>
+
+<ul data-name="notification">Notifications </ul>

--- a/spec/View/CoreViewMainContentMapperSpec.php
+++ b/spec/View/CoreViewMainContentMapperSpec.php
@@ -2,19 +2,52 @@
 
 namespace spec\EzSystems\HybridPlatformUi\View;
 
-use EzSystems\HybridPlatformUi\Components\MainContent;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\HybridPlatformUi\Components\App;
 use EzSystems\HybridPlatformUi\View\CoreViewMainContentMapper;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 
 class CoreViewMainContentMapperSpec extends ObjectBehavior
 {
-    function let(MainContent $mainContent)
+    function let(App $app)
     {
-        $this->beConstructedWith($mainContent);
+        $this->beConstructedWith($app);
     }
 
     function it_is_initializable()
     {
         $this->shouldHaveType(CoreViewMainContentMapper::class);
+    }
+
+    function it_throws_an_exception_on_map_if_the_argument_is_not_a_view()
+    {
+        $this->shouldThrow('\InvalidArgumentException')->during('map', [new \stdClass()]);
+    }
+
+    function it_maps_the_view_template_to_the_main_content(App $app, View $view)
+    {
+        $view->getTemplateIdentifier()->willReturn('template_identifier.html.twig');
+        $view->getParameters()->shouldBeCalled();
+        $app->setConfig(Argument::that(function ($value) {
+            return is_array($value) &&
+                isset($value['mainContent']) &&
+                isset($value['mainContent']['template']) &&
+                $value['mainContent']['template'] === 'template_identifier.html.twig';
+        }));
+        $this->map($view);
+    }
+
+    function it_maps_the_view_parameters_to_the_main_content(App $app, View $view)
+    {
+        $view->getTemplateIdentifier()->shouldBeCalled();
+        $view->getParameters()->willReturn(['param' => 'value']);
+        $app->setConfig(Argument::that(function ($value) {
+            return is_array($value) &&
+                isset($value['mainContent']) &&
+                isset($value['mainContent']['parameters']) &&
+                $value['mainContent']['parameters'] === ['param' => 'value'];
+        }));
+        $this->map($view);
     }
 }

--- a/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
+++ b/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
@@ -28,6 +28,7 @@ class EzSystemsHybridPlatformUiExtension extends Extension implements PrependExt
         $loader->load('services.yml');
         $loader->load('toolbars.yml');
         $loader->load('components.yml');
+        $loader->load('pjax.yml');
     }
 
     public function prepend(ContainerBuilder $container)

--- a/src/bundle/Resources/config/components.yml
+++ b/src/bundle/Resources/config/components.yml
@@ -5,8 +5,6 @@ services:
             - "@templating"
             - "@ezsystems.platformui.component.maincontent"
             - "@ezsystems.platformui.component.navigationhub"
-            # @todo tag those services so that it's possible to add
-            # new toolbars
             - ["@ezsystems.platformui.component.discoverybar"]
         public: false
 

--- a/src/bundle/Resources/config/components.yml
+++ b/src/bundle/Resources/config/components.yml
@@ -23,4 +23,3 @@ services:
         class: EzSystems\HybridPlatformUi\Components\MainContent
         arguments:
             - "@templating"
-        shared: false

--- a/src/bundle/Resources/config/navigationhub.yml
+++ b/src/bundle/Resources/config/navigationhub.yml
@@ -44,11 +44,9 @@ services:
         class: "%ezsystems.platformui.navigationhub.link.subtree.class%"
         arguments:
             - "@router"
-            # Should be Core content route
-            - "ez_urlalias"
             - "Content structure"
             - "content"
-            - {"locationId": 2}
+            - {locationId: 2}
         tags:
             - {name: ezplatform.ui.link}
         public: false
@@ -57,10 +55,9 @@ services:
         class: "%ezsystems.platformui.navigationhub.link.subtree.class%"
         arguments:
             - "@router"
-            - "ez_urlalias"
             - "Media Library"
             - "content"
-            - {"locationId": 2}
+            - {locationId: 43}
         tags:
             - {name: ezplatform.ui.link}
         public: false

--- a/src/bundle/Resources/config/navigationhub.yml
+++ b/src/bundle/Resources/config/navigationhub.yml
@@ -64,3 +64,75 @@ services:
         tags:
             - {name: ezplatform.ui.link}
         public: false
+
+    ezsystems.platformui.navigationhub.link.admin.dashboard:
+        class: "%ezsystems.platformui.navigationhub.link.route.class%"
+        arguments:
+            - "@router"
+            - "admin_dashboard"
+            - {}
+            - "Dashboard"
+            - "admin"
+        tags:
+            - {name: ezplatform.ui.link}
+        public: false
+
+    ezsystems.platformui.navigationhub.link.admin.section:
+        class: "%ezsystems.platformui.navigationhub.link.route.class%"
+        arguments:
+            - "@router"
+            - "admin_sectionlist"
+            - {}
+            - "Sections"
+            - "admin"
+        tags:
+            - {name: ezplatform.ui.link}
+        public: false
+
+    ezsystems.platformui.navigationhub.link.admin.languages:
+        class: "%ezsystems.platformui.navigationhub.link.route.class%"
+        arguments:
+            - "@router"
+            - "admin_languagelist"
+            - {}
+            - "Languages"
+            - "admin"
+        tags:
+            - {name: ezplatform.ui.link}
+        public: false
+
+    ezsystems.platformui.navigationhub.link.admin.content_types:
+        class: "%ezsystems.platformui.navigationhub.link.route.class%"
+        arguments:
+            - "@router"
+            - "admin_contenttypeGroupList"
+            - {}
+            - "Content types"
+            - "admin"
+        tags:
+            - {name: ezplatform.ui.link}
+        public: false
+
+    ezsystems.platformui.navigationhub.link.admin.roles:
+        class: "%ezsystems.platformui.navigationhub.link.route.class%"
+        arguments:
+            - "@router"
+            - "admin_roleList"
+            - {}
+            - "Roles"
+            - "admin"
+        tags:
+            - {name: ezplatform.ui.link}
+        public: false
+
+    ezsystems.platformui.navigationhub.link.admin.system_info:
+        class: "%ezsystems.platformui.navigationhub.link.route.class%"
+        arguments:
+            - "@router"
+            - "admin_systeminfo"
+            - {}
+            - "System info"
+            - "admin"
+        tags:
+            - {name: ezplatform.ui.link}
+        public: false

--- a/src/bundle/Resources/config/navigationhub.yml
+++ b/src/bundle/Resources/config/navigationhub.yml
@@ -46,9 +46,9 @@ services:
             - "@router"
             # Should be Core content route
             - "ez_urlalias"
-            - {"locationId": 2}
             - "Content structure"
             - "content"
+            - {"locationId": 2}
         tags:
             - {name: ezplatform.ui.link}
         public: false
@@ -58,9 +58,9 @@ services:
         arguments:
             - "@router"
             - "ez_urlalias"
-            - {"locationId": 2}
             - "Media Library"
             - "content"
+            - {"locationId": 2}
         tags:
             - {name: ezplatform.ui.link}
         public: false
@@ -70,7 +70,6 @@ services:
         arguments:
             - "@router"
             - "admin_dashboard"
-            - {}
             - "Dashboard"
             - "admin"
         tags:
@@ -82,9 +81,10 @@ services:
         arguments:
             - "@router"
             - "admin_sectionlist"
-            - {}
             - "Sections"
             - "admin"
+        calls:
+            - [setRoutePrefix, ["admin_section"]]
         tags:
             - {name: ezplatform.ui.link}
         public: false
@@ -94,9 +94,10 @@ services:
         arguments:
             - "@router"
             - "admin_languagelist"
-            - {}
             - "Languages"
             - "admin"
+        calls:
+            - [setRoutePrefix, ["admin_language"]]
         tags:
             - {name: ezplatform.ui.link}
         public: false
@@ -106,9 +107,10 @@ services:
         arguments:
             - "@router"
             - "admin_contenttypeGroupList"
-            - {}
             - "Content types"
             - "admin"
+        calls:
+            - [setRoutePrefix, ["admin_contenttype"]]
         tags:
             - {name: ezplatform.ui.link}
         public: false
@@ -118,9 +120,10 @@ services:
         arguments:
             - "@router"
             - "admin_roleList"
-            - {}
             - "Roles"
             - "admin"
+        calls:
+            - [setRoutePrefix, ["admin_role"]]
         tags:
             - {name: ezplatform.ui.link}
         public: false
@@ -130,7 +133,6 @@ services:
         arguments:
             - "@router"
             - "admin_systeminfo"
-            - {}
             - "System info"
             - "admin"
         tags:

--- a/src/bundle/Resources/config/pjax.yml
+++ b/src/bundle/Resources/config/pjax.yml
@@ -1,0 +1,15 @@
+services:
+    ezsystems.platformui.hybrid.event_subscriber.pjax_subscriber:
+        class: EzSystems\HybridPlatformUi\EventSubscriber\PjaxSubscriber
+        arguments:
+            - "@ezsystems.platformui.hybrid.mapper.pjax_response_to_main_content"
+            - "@ezsystems.platformui.hybrid.request_matcher.admin"
+            - "@ezsystems.platformui.pjax.request_matcher"
+        tags:
+            - {name: kernel.event_subscriber}
+
+    ezsystems.platformui.hybrid.mapper.pjax_response_to_main_content:
+        class: EzSystems\HybridPlatformUi\Pjax\PjaxResponseMainContentMapper
+        arguments:
+            - "@ezsystems.platformui.component.app"
+        public: false

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -54,5 +54,5 @@ services:
     ezsystems.platformui.hybrid.mapper.core_view_to_main_content:
         class: EzSystems\HybridPlatformUi\View\CoreViewMainContentMapper
         arguments:
-            - "@ezsystems.platformui.component.maincontent"
+            - "@ezsystems.platformui.component.app"
         public: false

--- a/src/lib/App/RequestAppResponseRenderer.php
+++ b/src/lib/App/RequestAppResponseRenderer.php
@@ -7,6 +7,7 @@
 namespace EzSystems\HybridPlatformUi\App;
 
 use EzSystems\HybridPlatformUi\Components\App;
+use EzSystems\HybridPlatformUi\Components\MainContent;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
@@ -35,7 +36,6 @@ class RequestAppResponseRenderer implements AppResponseRenderer
 
     public function render(Response $response, App $app)
     {
-        $app->setConfig(['mainContent' => ['result' => $response->getContent()]]);
         $this->configureToolbars($app);
 
         $appResponse = $this->ajaxUpdateRequestMatcher->matches($this->request)
@@ -50,7 +50,7 @@ class RequestAppResponseRenderer implements AppResponseRenderer
     /**
      * Configures the toolbars.
      *
-     * @todo Depends on the Request. Must be triggered by another event.
+     * @todo Depends on the Request. See http://github.com/ezsystems/hybrid-platform-ui/pull/4
      */
     private function configureToolbars(App $app)
     {

--- a/src/lib/EventSubscriber/ComponentRendererSubscriber.php
+++ b/src/lib/EventSubscriber/ComponentRendererSubscriber.php
@@ -30,10 +30,8 @@ class ComponentRendererSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $response = $this->ajaxUpdateRequestMatcher->matches($event->getRequest()) ?
-            new JsonResponse($component) :
-            new Response($component);
-
-        $event->setResponse($response);
+        // This is necessary to avoid an error because there is no Response.
+        // The actual Response will be rendered from the App.
+        $event->setResponse(new Response());
     }
 }

--- a/src/lib/EventSubscriber/CoreViewSubscriber.php
+++ b/src/lib/EventSubscriber/CoreViewSubscriber.php
@@ -6,6 +6,7 @@ use eZ\Publish\Core\MVC\Symfony\View\View;
 use EzSystems\HybridPlatformUi\Mapper\MainContentMapper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -47,6 +48,7 @@ class CoreViewSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $event->setControllerResult($this->mapper->map($view));
+        $this->mapper->map($view);
+        $event->setResponse(new Response());
     }
 }

--- a/src/lib/EventSubscriber/PjaxSubscriber.php
+++ b/src/lib/EventSubscriber/PjaxSubscriber.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\HybridPlatformUi\EventSubscriber;
+
+use EzSystems\HybridPlatformUi\Components\App;
+use EzSystems\HybridPlatformUi\Mapper\MainContentMapper;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Catches admin PJAX requests, and maps them to Hybrid views.
+ */
+class PjaxSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestMatcherInterface
+     */
+    private $adminRequestMatcher;
+
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestMatcherInterface
+     */
+    private $pjaxRequestMatcher;
+
+    /**
+     * @var \EzSystems\HybridPlatformUi\Pjax\PjaxResponseMainContentMapper
+     */
+    private $responseMapper;
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::RESPONSE => ['mapPjaxResponseToMainContent', 10]];
+    }
+
+    public function __construct(
+        MainContentMapper $responseMapper,
+        RequestMatcherInterface $adminRequestMatcher,
+        RequestMatcherInterface $pjaxRequestMatcher
+    ) {
+        $this->responseMapper = $responseMapper;
+        $this->adminRequestMatcher = $adminRequestMatcher;
+        $this->pjaxRequestMatcher = $pjaxRequestMatcher;
+    }
+
+    public function mapPjaxResponseToMainContent(FilterResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if (
+            $event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST ||
+            !$this->adminRequestMatcher->matches($request) ||
+            !$this->pjaxRequestMatcher->matches($request)
+        ) {
+            return;
+        }
+
+        $response = $event->getResponse();
+
+        // If AJAX update, follow the redirection and return the update for it.
+        // If not an AJAX update, send the redirection.
+        if ($response instanceof RedirectResponse) {
+            $event->stopPropagation();
+            return;
+        }
+
+        $this->responseMapper->map($response);
+    }
+}

--- a/src/lib/Http/ChainRequestMatcher.php
+++ b/src/lib/Http/ChainRequestMatcher.php
@@ -5,6 +5,9 @@ namespace EzSystems\HybridPlatformUi\Http;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * Matches a request using a set of request matchers
+ */
 class ChainRequestMatcher implements RequestMatcherInterface
 {
     /**
@@ -17,6 +20,13 @@ class ChainRequestMatcher implements RequestMatcherInterface
         $this->requestMatchers = $requestMatchers;
     }
 
+    /**
+     * Matches the request if ALL the chained request matchers match.
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return bool
+     */
     public function matches(Request $request)
     {
         foreach ($this->requestMatchers as $requestMatcher) {

--- a/src/lib/Mapper/MainContentMapper.php
+++ b/src/lib/Mapper/MainContentMapper.php
@@ -16,8 +16,6 @@ interface MainContentMapper
 {
     /**
      * @param mixed $value
-     *
-     * @return \EzSystems\HybridPlatformUi\Components\MainContent
      */
     public function map($value);
 }

--- a/src/lib/NavigationHub/Link/Route.php
+++ b/src/lib/NavigationHub/Link/Route.php
@@ -13,6 +13,7 @@ class Route extends Link
     protected $urlGenerator;
 
     /**
+     * @todo remove the name, and use i18n for the human readable string.
      * @var string
      */
     protected $routeName;

--- a/src/lib/NavigationHub/Link/Route.php
+++ b/src/lib/NavigationHub/Link/Route.php
@@ -18,14 +18,24 @@ class Route extends Link
     protected $routeName;
 
     /**
-     * @var string
+     * @var array
      */
     protected $routeParams;
 
-    public function __construct(UrlGeneratorInterface $urlGenerator, $routeName, $routeParams, $name, $zoneIdentifier)
+    public $zone;
+
+    public $name;
+
+    /**
+     * An optional route prefix used to match routes.
+     * @var string
+     */
+    protected $routePrefix;
+
+    public function __construct(UrlGeneratorInterface $urlGenerator, $routeName, $name, $zone, array $routeParams = [])
     {
         $this->urlGenerator = $urlGenerator;
-        $this->zone = $zoneIdentifier;
+        $this->zone = $zone;
         $this->name = $name;
         $this->routeName = $routeName;
         $this->routeParams = $routeParams;
@@ -42,8 +52,8 @@ class Route extends Link
         $routeParams = $request->attributes->get('_routeParams', []);
 
         return (
-            $this->matchRoute($routeName)
-            && $this->matchRouteParams($routeParams)
+            ($this->matchRoute($routeName) && $this->matchRouteParams($routeParams))
+            || $this->matchRoutePrefix($routeName)
         );
     }
 
@@ -63,5 +73,25 @@ class Route extends Link
             }
         }
         return true;
+    }
+
+    /**
+     * Matches $routeName against the configured route prefix, if any.
+     *
+     * @param string $routeName
+     *
+     * @return bool
+     */
+    protected function matchRoutePrefix($routeName)
+    {
+        return $this->routePrefix !== null && strpos($routeName, $this->routePrefix) === 0;
+    }
+
+    /**
+     * @param mixed $routePrefix
+     */
+    public function setRoutePrefix($routePrefix)
+    {
+        $this->routePrefix = $routePrefix;
     }
 }

--- a/src/lib/NavigationHub/Link/Subtree.php
+++ b/src/lib/NavigationHub/Link/Subtree.php
@@ -3,9 +3,14 @@
 namespace EzSystems\HybridPlatformUi\NavigationHub\Link;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class Subtree extends Route
 {
+    public function __construct(UrlGeneratorInterface $urlGenerator, $name, $zone, array $routeParams = []) {
+        parent::__construct($urlGenerator, 'ez_urlalias', $name, $zone, $routeParams);
+    }
+
     public function match(Request $request)
     {
         $location = $request->attributes->get('location');

--- a/src/lib/NavigationHub/Zone.php
+++ b/src/lib/NavigationHub/Zone.php
@@ -4,6 +4,9 @@ namespace EzSystems\HybridPlatformUi\NavigationHub;
 
 class Zone
 {
+    /**
+     * @todo remove the name, and use i18n for the human readable string.
+     */
     public $name;
 
     public $identifier;

--- a/src/lib/Pjax/PjaxResponseMainContentMapper.php
+++ b/src/lib/Pjax/PjaxResponseMainContentMapper.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Pjax;
+
+use EzSystems\HybridPlatformUi\Components\App;
+use EzSystems\HybridPlatformUi\Components\MainContent;
+use EzSystems\HybridPlatformUi\Mapper\MainContentMapper;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Maps a PJAX Response to the MainContent. And App.
+ */
+class PjaxResponseMainContentMapper implements MainContentMapper
+{
+    /**
+     * @var \EzSystems\HybridPlatformUi\Components\App
+     */
+    private $app;
+
+    public function __construct(App $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     *
+     * @throws \Exception
+     */
+    public function map($response)
+    {
+        if (!$response instanceof Response) {
+            throw new \InvalidArgumentException('Expected a \Symfony\Component\HttpFoundation\Response');
+        }
+
+        $responseContent = $response->getContent();
+
+        $errorHandling = libxml_use_internal_errors(true);
+
+        $doc = new \DOMDocument();
+        if (!$doc->loadHTML($responseContent)) {
+            $errors = libxml_get_errors();
+            libxml_use_internal_errors($errorHandling);
+            throw new \Exception(
+                "Error(s) occurred parsing the PJAX response:\n" .
+                implode("\n", $errors)
+            );
+        }
+
+        $xpath = new \DOMXPath($doc);
+        $title = $xpath->query('//div[@data-name="title"]')[0]->nodeValue;
+        $content = $this->innerHtml($xpath->query('//div[@data-name="html"]')[0]);
+
+        $this->app->setConfig([
+            'title' => $title,
+            'toolbars' => ['discovery' => 1],
+            'mainContent' => ['result' => $content]
+        ]);
+    }
+
+    private function innerHtml(\DOMElement $element)
+    {
+        $doc = $element->ownerDocument;
+
+        $html = '';
+
+        foreach ($element->childNodes as $node) {
+            $html .= $doc->saveHTML($node);
+        }
+
+        return $html;
+    }
+}

--- a/src/lib/View/CoreViewMainContentMapper.php
+++ b/src/lib/View/CoreViewMainContentMapper.php
@@ -7,25 +7,24 @@
 namespace EzSystems\HybridPlatformUi\View;
 
 use eZ\Publish\Core\MVC\Symfony\View\View;
+use EzSystems\HybridPlatformUi\Components\App;
 use EzSystems\HybridPlatformUi\Components\MainContent;
 use EzSystems\HybridPlatformUi\Mapper\MainContentMapper;
 
 class CoreViewMainContentMapper implements MainContentMapper
 {
     /**
-     * @var MainContent
+     * @var \EzSystems\HybridPlatformUi\Components\App
      */
-    private $mainContent;
+    private $app;
 
-    public function __construct(MainContent $mainContent)
+    public function __construct(App $app)
     {
-        $this->mainContent = $mainContent;
+        $this->app = $app;
     }
 
     /**
      * @param \eZ\Publish\Core\MVC\Symfony\View\View $view
-     *
-     * @return \EzSystems\HybridPlatformUi\Components\MainContent
      */
     public function map($view)
     {
@@ -33,9 +32,11 @@ class CoreViewMainContentMapper implements MainContentMapper
             throw new \InvalidArgumentException('Expected an \eZ\Publish\Core\MVC\Symfony\View\View');
         }
 
-        $this->mainContent->setTemplate($view->getTemplateIdentifier());
-        $this->mainContent->setParameters($view->getParameters());
-
-        return $this->mainContent;
+        $this->app->setConfig([
+            'mainContent' => [
+                'template' => $view->getTemplateIdentifier(),
+                'parameters' => $view->getParameters()
+            ]
+        ]);
     }
 }


### PR DESCRIPTION
> [EZP-27282](https://jira.ez.no/browse/EZP-27282)

Bridges the hybrid UI with the PJAX API in ezsystems/platform-ui-bundle.

It parses Responses from PJAX requests thanks to their semantic nature, and configures the App based on their contents. It maps the PJAX server-side-view content to the MainContent, and the PJAX title to the App's title.

<img width="916" alt="capture d ecran 2017-05-12 a 13 21 23" src="https://cloud.githubusercontent.com/assets/235928/25996139/eabd6440-3715-11e7-9606-386211718866.png">

### TODO
- [x] Issue link
- [x] Describe
- [x] Handle redirections (in general and after POST). Can be a follow-up, it works without it.
- [x] Handle navigation toggling for sub-routes (ex: sub parts of Section)
- [x] Fix phpspec
- [x] Squash most commits