### PR TITLE
[POC] Toolbars configuration

### DIFF
--- a/doc/requirements/toolbars.md
+++ b/doc/requirements/toolbars.md
@@ -1,0 +1,48 @@
+# Hybrid UI toolbars
+
+The Hybrid UI toolbars are meant to be customized and extended by any UI module.
+
+## Creating a toolbar
+New toolbars are created by defining a service tagged with the `ezplatform.ui.toolbar` tag,
+and giving it an alias. The definition below defines the `discovery` toolbar.
+
+```yml
+services:
+    ezsystems.hybrid_platform_ui.component.discoverybar:
+        class: EzSystems\HybridPlatformUi\Components\Toolbar
+        arguments:
+            - ~
+            - []
+        tags:
+            - {name: ezplatform.ui.toolbar, alias: "discovery"}
+```
+
+Any class implementing the `Component` interface can be used as a toolbar.
+
+## Adding items to a toolbar
+Items are added to a Toolbar by defining a `Component` as a services tagged with the `ezplatform.ui.toolbar_item` tag.
+The configuration block below adds the `search` toolbar item to the `discovery` toolbar:
+ 
+```yml
+services:
+    ezsystems.hybrid_platform_ui.component.search:
+        class: EzSystems\HybridPlatformUi\Components\Search
+        tags:
+            - {name: ezplatform.ui.toolbar_item, toolbar: "discovery"}
+```
+
+## Configuring a toolbar's visibility 
+The toolbars are hidden by default. Each page may enable the ones it uses.
+The configuration block below will show the `discovery` toolbar when on the `ez_urlalias` route, and the `section_admin`
+toolbar on any route that begins with `admin_section`.
+
+```yml
+ez_hybrid_platform_ui:
+    toolbars:
+        discovery:
+            visiblity:
+                - routes: ["ez_urlalias"]
+        section_admin:
+            visibility:
+                - routes: ["admin_section*"]
+```

--- a/spec/EventSubscriber/AppToolbarsSubscriberSpec.php
+++ b/spec/EventSubscriber/AppToolbarsSubscriberSpec.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\EventSubscriber;
+
+use EzSystems\HybridPlatformUi\EventSubscriber\AppToolbarsSubscriber;
+use PhpSpec\ObjectBehavior;
+
+class AppToolbarsSubscriberSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AppToolbarsSubscriber::class);
+    }
+}

--- a/spec/EventSubscriber/AppToolbarsSubscriberSpec.php
+++ b/spec/EventSubscriber/AppToolbarsSubscriberSpec.php
@@ -3,12 +3,68 @@
 namespace spec\EzSystems\HybridPlatformUi\EventSubscriber;
 
 use EzSystems\HybridPlatformUi\EventSubscriber\AppToolbarsSubscriber;
+use EzSystems\HybridPlatformUi\Toolbars\ToolbarsConfigurator;
 use PhpSpec\ObjectBehavior;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 class AppToolbarsSubscriberSpec extends ObjectBehavior
 {
+    function let(
+        GetResponseEvent $event,
+        Request $request,
+        RequestMatcherInterface $adminRequestMatcher,
+        ToolbarsConfigurator $configurator
+    ) {
+        $this->beConstructedWith($adminRequestMatcher, $configurator);
+        $event->getRequest()->willReturn($request);
+        $adminRequestMatcher->matches($request)->willReturn(true);
+    }
+
     function it_is_initializable()
     {
         $this->shouldHaveType(AppToolbarsSubscriber::class);
+        $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    function it_subscribes_to_the_request_kernel_event()
+    {
+        $this->getSubscribedEvents()->shouldSubscribeToEvent(KernelEvents::REQUEST);
+    }
+
+    function it_ignores_non_admin_requests(
+        GetResponseEvent $event,
+        Request $request,
+        RequestMatcherInterface $adminRequestMatcher,
+        ToolbarsConfigurator $configurator
+    ) {
+        $adminRequestMatcher->matches($request)->willReturn(false);
+        $configurator->fromRequest($request)->shouldNotBeCalled();
+
+        $this->configureAppToolbars($event);
+    }
+
+    function it_configures_the_toolbars(
+        GetResponseEvent $event,
+        Request $request,
+        ToolbarsConfigurator $configurator
+    ) {
+        $configurator->fromRequest($request)->shouldBeCalled();
+
+        $this->configureAppToolbars($event);
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'subscribeToEvent' => function (array $subscribedEvents, $event) {
+                return isset($subscribedEvents[$event])
+                    && is_array($subscribedEvents[$event])
+                    && count($subscribedEvents[$event]) === 2 || count($subscribedEvents[$event]) === 1;
+            },
+        ];
     }
 }

--- a/spec/Toolbars/RouteBasedConfiguratorSpec.php
+++ b/spec/Toolbars/RouteBasedConfiguratorSpec.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\Toolbars;
+
+use EzSystems\HybridPlatformUi\Toolbars\RouteBasedConfigurator;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class RouteBasedConfiguratorSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(RouteBasedConfigurator::class);
+    }
+}

--- a/spec/Toolbars/RouteBasedConfiguratorSpec.php
+++ b/spec/Toolbars/RouteBasedConfiguratorSpec.php
@@ -2,14 +2,70 @@
 
 namespace spec\EzSystems\HybridPlatformUi\Toolbars;
 
+use EzSystems\HybridPlatformUi\Components\App;
 use EzSystems\HybridPlatformUi\Toolbars\RouteBasedConfigurator;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
 
 class RouteBasedConfiguratorSpec extends ObjectBehavior
 {
+    function let(
+        App $app,
+        Request $request,
+        ParameterBag $requestAttributes
+    ) {
+        $request->attributes = $requestAttributes;
+        $this->beConstructedWith($app);
+    }
+
     function it_is_initializable()
     {
         $this->shouldHaveType(RouteBasedConfigurator::class);
+    }
+
+    function it_can_be_added_routes_mappings()
+    {
+        $this->addRoutesMappings([
+            'some_route' => ['toolbar' => 1],
+            'some_other_route' => ['other_toolbar' => 1]
+        ]);
+    }
+
+    function it_ignores_requests_that_do_not_have_a_route(
+        App $app,
+        Request $request,
+        ParameterBag $requestAttributes
+    ) {
+        $requestAttributes->has('_route')->willReturn(false);
+        $app->setConfig(Argument::any())->shouldNotBeCalled();
+
+        $this->fromRequest($request);
+    }
+
+    function it_does_not_configure_the_toolbars_if_there_is_no_matching_routes_mapping(
+        App $app,
+        Request $request,
+        ParameterBag $requestAttributes
+    ) {
+        $requestAttributes->has('_route')->willReturn(true);
+        $requestAttributes->get('_route')->willReturn('other_route');
+        $app->setConfig(Argument::any())->shouldNotBeCalled();
+
+        $this->fromRequest($request);
+    }
+
+    function it_configures_the_toolbars_with_the_matching_mapping(
+        App $app,
+        Request $request,
+        ParameterBag $requestAttributes
+    ) {
+        $requestAttributes->has('_route')->willReturn(true);
+        $requestAttributes->get('_route')->willReturn('some_route');
+        $this->addRoutesMappings(['some_route' => ['toolbar' => 1]]);
+        $app->setConfig(['toolbars' => ['toolbar' => 1]])->shouldBeCalled();
+
+        $this->fromRequest($request);
     }
 }

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -48,4 +48,11 @@ services:
         alias: EzSystems\HybridPlatformUi\Http\ChainHybridRequestMatcher
 
     EzSystems\HybridPlatformUi\View\CoreViewMainContentMapper:
-        alias: 'EzSystems\HybridPlatformUi\View\AppConfigCoreViewMainContentMapper'
+        alias: EzSystems\HybridPlatformUi\View\AppConfigCoreViewMainContentMapper
+
+    EzSystems\HybridPlatformUi\Toolbars\ToolbarsConfigurator:
+        alias: EzSystems\HybridPlatformUi\Toolbars\RouteBasedConfigurator
+
+    EzSystems\HybridPlatformUi\Toolbars\RouteBasedConfigurator:
+        calls:
+            - [addRoutesMappings, [{'ez_urlalias': {'discovery': 1}}]]

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -52,7 +52,3 @@ services:
 
     EzSystems\HybridPlatformUi\Toolbars\ToolbarsConfigurator:
         alias: EzSystems\HybridPlatformUi\Toolbars\RouteBasedConfigurator
-
-    EzSystems\HybridPlatformUi\Toolbars\RouteBasedConfigurator:
-        calls:
-            - [addRoutesMappings, [{'ez_urlalias': {'discovery': 1}}]]

--- a/src/lib/App/RequestAppResponseRenderer.php
+++ b/src/lib/App/RequestAppResponseRenderer.php
@@ -33,8 +33,6 @@ class RequestAppResponseRenderer implements AppResponseRenderer
 
     public function render(Response $response, App $app)
     {
-        $this->configureToolbars($app);
-
         $appResponse = $this->ajaxUpdateRequestMatcher->matches($this->request)
             ? new JsonResponse($app)
             : new Response($app);
@@ -42,15 +40,5 @@ class RequestAppResponseRenderer implements AppResponseRenderer
         $response
             ->setContent($appResponse->getContent())
             ->headers->replace($appResponse->headers->all());
-    }
-
-    /**
-     * Configures the toolbars.
-     *
-     * @todo Depends on the Request. See http://github.com/ezsystems/hybrid-platform-ui/pull/4
-     */
-    private function configureToolbars(App $app)
-    {
-        $app->setConfig(['toolbars' => ['discovery' => 1]]);
     }
 }

--- a/src/lib/EventSubscriber/AppToolbarsSubscriber.php
+++ b/src/lib/EventSubscriber/AppToolbarsSubscriber.php
@@ -2,6 +2,49 @@
 
 namespace EzSystems\HybridPlatformUi\EventSubscriber;
 
-class AppToolbarsSubscriber
+use EzSystems\HybridPlatformUi\Components\App;
+use EzSystems\HybridPlatformUi\Toolbars\ToolbarsConfigurator;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class AppToolbarsSubscriber implements EventSubscriberInterface
 {
+    /**
+     * @var \EzSystems\HybridPlatformUi\Components\App
+     */
+    private $app;
+
+    /**
+     * @var \EzSystems\HybridPlatformUi\Toolbars\ToolbarsConfigurator
+     */
+    private $configurator;
+
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestMatcherInterface
+     */
+    private $requestMatcher;
+
+    public function __construct(
+        RequestMatcherInterface $requestMatcher,
+        ToolbarsConfigurator $configurator
+    ) {
+        $this->configurator = $configurator;
+        $this->requestMatcher = $requestMatcher;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::REQUEST => ['configureAppToolbars']];
+    }
+
+    public function configureAppToolbars(GetResponseEvent $event)
+    {
+        if (!$this->requestMatcher->matches($event->getRequest())) {
+            return false;
+        }
+
+        $this->configurator->fromRequest($event->getRequest());
+    }
 }

--- a/src/lib/EventSubscriber/AppToolbarsSubscriber.php
+++ b/src/lib/EventSubscriber/AppToolbarsSubscriber.php
@@ -3,6 +3,7 @@
 namespace EzSystems\HybridPlatformUi\EventSubscriber;
 
 use EzSystems\HybridPlatformUi\Components\App;
+use EzSystems\HybridPlatformUi\Http\HybridRequestMatcher;
 use EzSystems\HybridPlatformUi\Toolbars\ToolbarsConfigurator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
@@ -24,14 +25,14 @@ class AppToolbarsSubscriber implements EventSubscriberInterface
     /**
      * @var \Symfony\Component\HttpFoundation\RequestMatcherInterface
      */
-    private $requestMatcher;
+    private $hybridRequestMatcher;
 
     public function __construct(
-        RequestMatcherInterface $requestMatcher,
+        HybridRequestMatcher $hybridRequestMatcher,
         ToolbarsConfigurator $configurator
     ) {
         $this->configurator = $configurator;
-        $this->requestMatcher = $requestMatcher;
+        $this->hybridRequestMatcher = $hybridRequestMatcher;
     }
 
     public static function getSubscribedEvents()
@@ -41,7 +42,7 @@ class AppToolbarsSubscriber implements EventSubscriberInterface
 
     public function configureAppToolbars(GetResponseEvent $event)
     {
-        if (!$this->requestMatcher->matches($event->getRequest())) {
+        if (!$this->hybridRequestMatcher->matches($event->getRequest())) {
             return false;
         }
 

--- a/src/lib/EventSubscriber/AppToolbarsSubscriber.php
+++ b/src/lib/EventSubscriber/AppToolbarsSubscriber.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\EventSubscriber;
+
+class AppToolbarsSubscriber
+{
+}

--- a/src/lib/Pjax/DomXpathPjaxResponseMainContentMapper.php
+++ b/src/lib/Pjax/DomXpathPjaxResponseMainContentMapper.php
@@ -68,7 +68,6 @@ class DomXpathPjaxResponseMainContentMapper implements PjaxResponseMainContentMa
 
         $this->app->setConfig([
             'title' => $title,
-            'toolbars' => ['discovery' => 1],
             'mainContent' => ['result' => '<ez-server-side-content>' . $content . '</ez-server--side-content>'],
             'notifications' => $this->buildNotifications($notificationElements),
         ]);

--- a/src/lib/Toolbars/RouteBasedConfigurator.php
+++ b/src/lib/Toolbars/RouteBasedConfigurator.php
@@ -2,6 +2,43 @@
 
 namespace EzSystems\HybridPlatformUi\Toolbars;
 
-class RouteBasedConfigurator
+use EzSystems\HybridPlatformUi\Components\App;
+use Symfony\Component\HttpFoundation\Request;
+
+class RouteBasedConfigurator implements ToolbarsConfigurator
 {
+    /**
+     * @var App
+     */
+    private $app;
+
+    /**
+     * @var array
+     */
+    private $mappings = [];
+
+    public function __construct(App $app)
+    {
+        $this->app = $app;
+    }
+
+    public function addRoutesMappings(array $mappings)
+    {
+        $this->mappings = array_merge($mappings);
+    }
+
+    public function fromRequest(Request $request)
+    {
+        if (!$request->attributes->has('_route')) {
+            return;
+        }
+
+        $route = $request->attributes->get('_route');
+
+        if (!isset($this->mappings[$route])) {
+            return;
+        }
+
+        $this->app->setConfig(['toolbars' => $this->mappings[$route]]);
+    }
 }

--- a/src/lib/Toolbars/RouteBasedConfigurator.php
+++ b/src/lib/Toolbars/RouteBasedConfigurator.php
@@ -20,6 +20,9 @@ class RouteBasedConfigurator implements ToolbarsConfigurator
     public function __construct(App $app)
     {
         $this->app = $app;
+        $this->mappings = [
+            'ez_urlalias' => ['discovery' => 1],
+        ];
     }
 
     public function addRoutesMappings(array $mappings)

--- a/src/lib/Toolbars/RouteBasedConfigurator.php
+++ b/src/lib/Toolbars/RouteBasedConfigurator.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Toolbars;
+
+class RouteBasedConfigurator
+{
+}

--- a/src/lib/Toolbars/ToolbarsConfigurator.php
+++ b/src/lib/Toolbars/ToolbarsConfigurator.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Toolbars;
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface ToolbarsConfigurator
+{
+    public function fromRequest(Request $rest);
+}


### PR DESCRIPTION
> [EZP-27322](https://jira.ez.no/browse/EZP-27322)

Proof-of-concept / experiment on Hybrid UI toolbars configuration. The current code implements a simple mapping of a route to an array: `['ez_urlalias' => ['discovery' => 1]]`. It is meant to be provided to the service by means of semantic configuration.

Ideas of more complex/different/extra options:
- Route wildcards
- RequestUri matching

The aim is to make it as convenient and simple as possible for UI modules developers to develop new toolbars and link them to parts of the hybrid UI. It may include custom ones, but also existing ones, or other 3rd parties.

### TODO
- [ ] Elaborate the story
- [ ] Write requirements & specifications documents