### PR TITLE
Custom main content element name

### DIFF
--- a/src/bundle/Resources/public/css/modules/content-view.css
+++ b/src/bundle/Resources/public/css/modules/content-view.css
@@ -1,0 +1,13 @@
+.ez-content-view {
+    display: flex;
+}
+
+.ez-content-view .ez-content-view-column {
+    flex: 1 0;
+}
+
+.ez-content-view .ez-action-bar {
+    flex: 0 0 115px;
+    background: var(--ez-color-action-bar);
+    color: var(--ez-color-text-base-inverted);
+}

--- a/src/bundle/Resources/public/css/structure.css
+++ b/src/bundle/Resources/public/css/structure.css
@@ -38,29 +38,12 @@ ez-toolbar .ez-button {
     border-color: transparent;
 }
 
-/* FIXME: after https://jira.ez.no/browse/EZP-27357, following selector should be
- * by #ez-hybrid-app-main-content
- */
-ez-main-content {
+main {
     flex: 1 1;
     display: flex;
     flex-direction: column;
 }
 
-/* FIXME: after https://jira.ez.no/browse/EZP-27357, this should be in a stylesheet
- * dedicated to content view
- */
-ez-main-content .ez-content-view {
-    flex: 1 0;
-    display: flex;
-}
-
-ez-main-content .ez-content-view-column {
-    flex: 1 0;
-}
-
-ez-main-content .ez-action-bar {
-    flex: 0 0 115px;
-    background: var(--ez-color-action-bar);
-    color: var(--ez-color-text-base-inverted);
+main > *:first-child {
+    flex: 1 1;
 }

--- a/src/bundle/Resources/public/css/structure.css
+++ b/src/bundle/Resources/public/css/structure.css
@@ -17,7 +17,7 @@ ez-navigation-hub {
     flex: 0 0;
 }
 
-main {
+div#app-content {
     flex: 1 0;
     display: flex;
 }

--- a/src/bundle/Resources/public/webcomponents/ez-server-side-content.html
+++ b/src/bundle/Resources/public/webcomponents/ez-server-side-content.html
@@ -2,19 +2,20 @@
 <link rel="import" href="../../../assets/ezplatform/hybrid-platform-ui-core-components/mixins/ez-tabs.html">
 
 <style>
-ez-main-content {
+ez-server-side-content {
     display: block;
 }
 </style>
 
 <script>
 (function () {
-    class eZMainContent extends eZ.TabsMixin(Polymer.Element) {
+    // this is where we could detect the markup structure to enhance it (tabs, selection table, ...)
+    class ServerSideContent extends eZ.TabsMixin(Polymer.Element) {
         static get is() {
-            return 'ez-main-content';
+            return 'ez-server-side-content';
         }
     }
 
-    customElements.define(eZMainContent.is, eZMainContent);
+    customElements.define(ServerSideContent.is, ServerSideContent);
 })();
 </script>

--- a/src/bundle/Resources/views/components/app.html.twig
+++ b/src/bundle/Resources/views/components/app.html.twig
@@ -1,27 +1,25 @@
 {% extends "@EzSystemsHybridPlatformUi/layout.html.twig" %}
 
 {% block app %}
+<{{ tagName }}
 
-<{{ tagName }}>
+{% block navigationHub %}
+    {{ navigationHub|raw }}
+{% endblock %}
 
-    {% block navigationHub %}
-        {{ navigationHub|raw }}
+<div id="app-content">
+    {% block toolbars %}
+        {% for toolbar in toolbars %}
+            {{ toolbar|raw }}
+        {% endfor %}
     {% endblock %}
 
-    {% block main %}
-        <main>
-            {% block toolbars %}
-                {% for toolbar in toolbars %}
-                    {{ toolbar|raw }}
-                {% endfor %}
-            {% endblock %}
+    <main>
+        {% block mainContent %}
+            {{ mainContent|raw }}
+        {% endblock %}
+    </main>
+</div>
 
-            {% block mainContent %}
-                {{ mainContent|raw }}
-            {% endblock %}
-        </main>
-    {% endblock %}
-
-</{{ tagName }}>
-
+</{{ tagName }}
 {% endblock %}

--- a/src/bundle/Resources/views/dashboard.html.twig
+++ b/src/bundle/Resources/views/dashboard.html.twig
@@ -1,1 +1,3 @@
-<h1>Dashboard</h1>
+<ez-server-side-content>
+    <h1>Dashboard</h1>
+</ez-server-side-content>

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -27,6 +27,7 @@
     <link rel="stylesheet" href="{{ asset('bundles/ezsystemshybridplatformui/css/modules/button.css') }}">
     <link rel="stylesheet" href="{{ asset('bundles/ezsystemshybridplatformui/css/modules/tabs.css') }}">
     <link rel="stylesheet" href="{{ asset('bundles/ezsystemshybridplatformui/css/modules/navigation-hub.css') }}">
+    <link rel="stylesheet" href="{{ asset('bundles/ezsystemshybridplatformui/css/modules/content-view.css') }}">
     <link rel="stylesheet" href="{{ asset('bundles/ezsystemshybridplatformui/css/modules/page-header.css') }}">
     <link rel="stylesheet" href="{{ asset('bundles/ezsystemshybridplatformui/css/modules/breadcrumbs.css') }}">
     <link rel="stylesheet" href="{{ asset('bundles/ezsystemshybridplatformui/css/modules/table-data.css') }}">

--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -12,7 +12,7 @@
     <script src="{{ asset('assets/ezplatform/webcomponentsjs/webcomponents-lite.js') }}"></script>
 
     <link rel="import" href="{{ asset( 'assets/ezplatform/hybrid-platform-ui-core-components/core-components.html' ) }}">
-    <link rel="import" href="{{ asset( 'bundles/ezsystemshybridplatformui/webcomponents/ez-main-content.html' ) }}">
+    <link rel="import" href="{{ asset( 'bundles/ezsystemshybridplatformui/webcomponents/ez-server-side-content.html' ) }}">
     <link rel="import" href="{{ asset( 'bundles/ezsystemshybridplatformui/webcomponents/ez-browse.html' ) }}">
 
     <link rel="import" href="{{ asset( 'bundles/ezplatformui/webcomponents/ez-subitem.html' ) }}">

--- a/src/bundle/Resources/views/locationview.html.twig
+++ b/src/bundle/Resources/views/locationview.html.twig
@@ -1,7 +1,4 @@
-{# FIXME: remove that and fix the corresponding CSS when
- # https://jira.ez.no/browse/EZP-27357 is implemented
- #}
-<ez-server-side-content>
+<ez-server-side-content class="ez-content-view">
     <section class="ez-content-view-column ez-tabs">
     {% block contentview %}
         {% block contentview_details %}

--- a/src/bundle/Resources/views/locationview.html.twig
+++ b/src/bundle/Resources/views/locationview.html.twig
@@ -44,15 +44,13 @@
         </div>
         {% endblock contentview_details %}
 
-        <hr>
-
         {% block subitems %}
         <ez-subitem parent-location-id="{{ location.id }}">
             Loading subitems...
         </ez-subitem>
         {% endblock %}
     </section>
-    <ez-toolbar class="ez-action-bar" id="action" visible>
+    <ez-toolbar class="ez-action-bar" visible>
         {% block content_action_toolbar %}
         {% endblock %}
     </ez-toolbar>

--- a/src/bundle/Resources/views/locationview.html.twig
+++ b/src/bundle/Resources/views/locationview.html.twig
@@ -1,7 +1,7 @@
 {# FIXME: remove that and fix the corresponding CSS when
  # https://jira.ez.no/browse/EZP-27357 is implemented
  #}
-<ez-server-side-view>
+<ez-server-side-content>
     <section class="ez-content-view-column ez-tabs">
     {% block contentview %}
         {% block contentview_details %}
@@ -60,4 +60,5 @@
         {% endblock %}
     </ez-toolbar>
     {% endblock %}
-</ez-server-side-view>
+    </section>
+</ez-server-side-content>

--- a/src/bundle/Resources/views/locationview.html.twig
+++ b/src/bundle/Resources/views/locationview.html.twig
@@ -1,8 +1,10 @@
 {# FIXME: remove that and fix the corresponding CSS when
  # https://jira.ez.no/browse/EZP-27357 is implemented
  #}
-<div class="ez-content-view">
+<ez-server-side-view>
     <section class="ez-content-view-column ez-tabs">
+    {% block contentview %}
+        {% block contentview_details %}
         <header class="ez-page-header">
             <h1>{{ ez_content_name(content) }}</h1>
         </header>
@@ -43,12 +45,19 @@
                 <p>Relation and reverse relation list should be generated here</p>
             </div>
         </div>
+        {% endblock contentview_details %}
 
+        <hr>
+
+        {% block subitems %}
         <ez-subitem parent-location-id="{{ location.id }}">
             Loading subitems...
         </ez-subitem>
+        {% endblock %}
     </section>
-    <ez-toolbar class="ez-action-bar" visible>
-
+    <ez-toolbar class="ez-action-bar" id="action" visible>
+        {% block content_action_toolbar %}
+        {% endblock %}
     </ez-toolbar>
-</div>
+    {% endblock %}
+</ez-server-side-view>

--- a/src/lib/Components/MainContent.php
+++ b/src/lib/Components/MainContent.php
@@ -2,11 +2,8 @@
 
 namespace EzSystems\HybridPlatformUi\Components;
 
-// TODO find a better name
 class MainContent implements Component
 {
-    const TAG_NAME = 'ez-main-content';
-
     protected $templating;
 
     protected $template = null;
@@ -37,24 +34,23 @@ class MainContent implements Component
 
     public function __toString()
     {
-        $str = '<' . self::TAG_NAME . '>';
+        $string = '';
         if ($this->result) {
-            $str .= $this->result;
+            $string =$this->result;
         } elseif ($this->template) {
-            $str .= $this->templating->render(
+            $string = $this->templating->render(
                 $this->template,
                 $this->parameters
             );
         }
-        $str .= '</' . self::TAG_NAME . '>';
 
-        return $str;
+        return $string;
     }
 
     public function jsonSerialize()
     {
         return [
-            'selector' => self::TAG_NAME,
+            'selector' => 'main',
             'update' => (string)$this,
         ];
     }

--- a/src/lib/Pjax/PjaxResponseMainContentMapper.php
+++ b/src/lib/Pjax/PjaxResponseMainContentMapper.php
@@ -54,7 +54,7 @@ class PjaxResponseMainContentMapper implements MainContentMapper
         $this->app->setConfig([
             'title' => $title,
             'toolbars' => ['discovery' => 1],
-            'mainContent' => ['result' => $content]
+            'mainContent' => ['result' => "<ez-serverside-view>" . $content . "</ez-serverside-view>"]
         ]);
     }
 

--- a/src/lib/Pjax/PjaxResponseMainContentMapper.php
+++ b/src/lib/Pjax/PjaxResponseMainContentMapper.php
@@ -54,7 +54,7 @@ class PjaxResponseMainContentMapper implements MainContentMapper
         $this->app->setConfig([
             'title' => $title,
             'toolbars' => ['discovery' => 1],
-            'mainContent' => ['result' => "<ez-serverside-view>" . $content . "</ez-serverside-view>"]
+            'mainContent' => ['result' => "<ez-serverside-content>" . $content . "</ez-serverside-content>"]
         ]);
     }
 


### PR DESCRIPTION
> [EZP-27357](http://jira.ez.no/browse/EZP-27357)

Changes the markup so that the mainContent DOM element is defined by the MainContent template or result, and not the MainContent itself.

### TODO
- [x] Describe
- [x] Update the `PjaxMapper` so that it adds a root element (equivalent of locationview's `ez-content-view`)
- [x] ~~Change hybrid-ui-core-components string update~~ (https://github.com/ezsystems/hybrid-platform-ui-core-components/pull/12)
- [x] See if `<ez-serverside-view>` is a good name for pjax pages
- [x] Fix conflicts
- [x] Update the CSS to match the markup