### PR TITLE
EZP-27457: prevent authorization fatal errors in navigation hub

### DIFF
--- a/src/bundle/Resources/views/components/navigationhub.html.twig
+++ b/src/bundle/Resources/views/components/navigationhub.html.twig
@@ -13,7 +13,7 @@
         <ul class="ez-navigation">
         {% for link in links %}
         <li data-zone="{{ link.zone }}" class="ez-zone-link {% if link.match(app.request) %} {{ matchedLinkClass }}{% endif %}">
-            <a href="{{ link.url }}">{{ link.name }}</a>
+            {{ link|raw }}
         </li>
         {% endfor %}
         </ul>

--- a/src/lib/NavigationHub/Link.php
+++ b/src/lib/NavigationHub/Link.php
@@ -11,4 +11,27 @@ abstract class Link
     public $name;
 
     abstract public function match(Request $request);
+
+    /**
+     * Returns the URL for the link.
+     *
+     * @return string|null The URL, or null if it could not be generated.
+     */
+    abstract public function getUrl();
+
+    public function __toString()
+    {
+        $disabled = '';
+        $url = $this->getUrl();
+
+        if ($url === null) {
+            $url = '#';
+            $disabled = ' data-disabled';
+        }
+
+        return sprintf(
+            '<a href="%s"%s>%s</a>',
+            $url, $disabled, htmlentities($this->name, ENT_HTML5)
+        );
+    }
 }

--- a/src/lib/NavigationHub/Link/Route.php
+++ b/src/lib/NavigationHub/Link/Route.php
@@ -1,6 +1,7 @@
 <?php
 namespace EzSystems\HybridPlatformUi\NavigationHub\Link;
 
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use EzSystems\HybridPlatformUi\NavigationHub\Link;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -44,7 +45,11 @@ class Route extends Link
 
     public function getUrl()
     {
-        return $this->urlGenerator->generate($this->routeName, $this->routeParams);
+        try {
+            return $this->urlGenerator->generate($this->routeName, $this->routeParams);
+        } catch (UnauthorizedException $e) {
+            return null;
+        }
     }
 
     public function match(Request $request)


### PR DESCRIPTION
> [EZP-27457](http://jira.ez.no/browse/EZP-27457)

Catches `UnauthorizedException` when generating links (Router -> UrlAliasRouter -> LoadLocation), and returns an empty link.

The empty link isn't a very good solution, but at least it avoids fatal errors. Should something be done on the frontend to complete this ? We also have the option of changing the link further from `navigationhub.html.twig`.