### PR TITLE
EZP-27109: update the Symfony Web Debug Toolbar during navigation

### DIFF
--- a/src/bundle/Resources/views/layout.html.twig
+++ b/src/bundle/Resources/views/layout.html.twig
@@ -35,13 +35,30 @@
     <link rel="stylesheet" href="{{ asset('bundles/ezsystemshybridplatformui/css/modules/content-field.css') }}">
 
     <script>
-        // FIXME:
-        // https://jira.ez.no/browse/EZP-27359
-        // this is a workaround to FOSJsRoutingBundle not generating URL for the admin SA
-        // of course, this only works when eZ Platform has one SA group and if the admin SA is not
-        // configured with a different matching strategy than URI...
+        {#
+            FIXME:
+            // https://jira.ez.no/browse/EZP-27359
+            // this is a workaround to FOSJsRoutingBundle not generating URL for the admin SA
+            // of course, this only works when eZ Platform has one SA group and if the admin SA is not
+            // configured with a different matching strategy than URI...
+        #}
         Routing.setBaseUrl('/admin');
     </script>
+
+{% if app.debug %}
+    <script>
+    document.addEventListener('ez:app:updated', function (e) {
+        if (!Sfjs || !e.detail.response.headers.has('x-debug-token')) {
+            return;
+        }
+
+        Sfjs.load(
+            document.querySelector('.sf-toolbar').id,
+            Routing.generate('_wdt', {token: e.detail.response.headers.get('x-debug-token')})
+        );
+    });
+    </script>
+{% endif %}
 </head>
 <body>
     {% block app %}


### PR DESCRIPTION
> [EZP-27109](http://jira.ez.no/browse/EZP-27109)
> Replaces https://github.com/ezsystems/hybrid-platform-ui-core-components/pull/15
> Requires https://github.com/ezsystems/hybrid-platform-ui-core-components/pull/17

Listens to the `ez:app:updated` event, and reloads the Symfony Web Debug Toolbar after update requests.