### PR TITLE
EZP-27501: use pjax as a pagelayout

### DIFF
--- a/spec/EventSubscriber/PjaxSubscriberSpec.php
+++ b/spec/EventSubscriber/PjaxSubscriberSpec.php
@@ -4,6 +4,7 @@ namespace spec\EzSystems\HybridPlatformUi\EventSubscriber;
 
 use EzSystems\HybridPlatformUi\EventSubscriber\PjaxSubscriber;
 use EzSystems\HybridPlatformUi\Mapper\MainContentMapper;
+use EzSystems\HybridPlatformUi\Pjax\PjaxResponseMatcher;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -19,18 +20,20 @@ class PjaxSubscriberSpec extends ObjectBehavior
     function let(
         FilterResponseEvent $event,
         MainContentMapper $mapper,
-        Request $request,
         RequestMatcherInterface $adminRequestMatcher,
         RequestMatcherInterface $pjaxRequestMatcher,
+        PjaxResponseMatcher $pjaxResponseMatcher,
+        Request $request,
         Response $response
     ) {
-        $this->beConstructedWith($mapper, $adminRequestMatcher, $pjaxRequestMatcher);
-
         $event->getRequest()->willReturn($request);
         $event->getResponse()->willReturn($response);
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+
         $adminRequestMatcher->matches($request)->willReturn(true);
         $pjaxRequestMatcher->matches($request)->willReturn(true);
-        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+
+        $this->beConstructedWith($mapper, $adminRequestMatcher, $pjaxRequestMatcher, $pjaxResponseMatcher);
     }
 
     function it_is_initializable()
@@ -42,7 +45,6 @@ class PjaxSubscriberSpec extends ObjectBehavior
     function it_ignores_sub_requests(FilterResponseEvent $event)
     {
         $event->getRequestType()->willReturn(HttpKernelInterface::SUB_REQUEST);
-        $event->getResponse()->shouldNotBeCalled();
 
         $this->mapPjaxResponseToMainContent($event);
     }
@@ -53,7 +55,6 @@ class PjaxSubscriberSpec extends ObjectBehavior
         RequestMatcherInterface $adminRequestMatcher
     ) {
         $adminRequestMatcher->matches($request)->willReturn(false);
-        $event->getResponse()->shouldNotBeCalled();
 
         $this->mapPjaxResponseToMainContent($event);
     }
@@ -64,7 +65,6 @@ class PjaxSubscriberSpec extends ObjectBehavior
         RequestMatcherInterface $pjaxRequestMatcher
     ) {
         $pjaxRequestMatcher->matches($request)->willReturn(false);
-        $event->getResponse()->shouldNotBeCalled();
 
         $this->mapPjaxResponseToMainContent($event);
     }

--- a/spec/Pjax/MarkupPjaxResponseMatcherSpec.php
+++ b/spec/Pjax/MarkupPjaxResponseMatcherSpec.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\Pjax;
+
+use EzSystems\HybridPlatformUi\Http\ResponseMatcherInterface;
+use EzSystems\HybridPlatformUi\Pjax\MarkupPjaxResponseMatcher;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\Response;
+
+class MarkupPjaxResponseMatcherSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MarkupPjaxResponseMatcher::class);
+        $this->shouldHaveType(ResponseMatcherInterface::class);
+    }
+
+    function it_matches_responses_that_have_the_pjax_markup_as_content(
+        Response $response
+    ) {
+        $response->getContent()->willReturn('_fixtures/pjax_response.html');
+
+        $this->matches($response)->shouldBe(false);
+    }
+
+    function it_matches_responses_that_does_not_have_the_pjax_markup_as_content(
+        Response $response
+    ) {
+        $response->getContent()->willReturn('_fixtures/lambda.html');
+
+        $this->matches($response)->shouldBe(false);
+    }
+}

--- a/spec/Pjax/_fixtures/lambda.html
+++ b/spec/Pjax/_fixtures/lambda.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Lambda HTML</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
+++ b/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
@@ -35,6 +35,7 @@ class EzSystemsHybridPlatformUiExtension extends Extension implements PrependExt
     {
         $this->prependViewsConfiguration($container);
         $this->prependFosJsRoutingConfiguration($container);
+        $this->prependLayoutConfiguration($container);
     }
 
     private function prependViewsConfiguration(ContainerBuilder $container)
@@ -50,6 +51,13 @@ class EzSystemsHybridPlatformUiExtension extends Extension implements PrependExt
         $configFile = __DIR__ . '/../Resources/config/fos_js_routing.yml';
         $config = Yaml::parse(file_get_contents($configFile));
         $container->prependExtensionConfig('fos_js_routing', $config);
+    }
+
+    private function prependLayoutConfiguration(ContainerBuilder $container)
+    {
+        $configFile = __DIR__ . '/../Resources/config/layout.yml';
+        $config = Yaml::parse(file_get_contents($configFile));
+        $container->prependExtensionConfig('ezpublish', $config);
         $container->addResource(new FileResource($configFile));
     }
 }

--- a/src/bundle/Resources/config/layout.yml
+++ b/src/bundle/Resources/config/layout.yml
@@ -1,0 +1,5 @@
+system:
+    admin_group:
+        pagelayout: 'EzSystemsHybridPlatformUiBundle::pjax_layout.html.twig'
+        user:
+            layout: 'EzSystemsHybridPlatformUiBundle::pjax_layout.html.twig'

--- a/src/bundle/Resources/config/pjax.yml
+++ b/src/bundle/Resources/config/pjax.yml
@@ -1,4 +1,9 @@
 services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
     ezsystems.platformui.hybrid.event_subscriber.pjax_subscriber:
         class: EzSystems\HybridPlatformUi\EventSubscriber\PjaxSubscriber
         arguments:
@@ -13,3 +18,7 @@ services:
         arguments:
             - "@ezsystems.platformui.component.app"
         public: false
+
+    EzSystems\HybridPlatformUi\Pjax\PjaxResponseMatcher: '@EzSystems\HybridPlatformUi\Pjax\MarkupPjaxResponseMatcher'
+
+    EzSystems\HybridPlatformUi\Pjax\MarkupPjaxResponseMatcher: ~

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -38,7 +38,7 @@ services:
     ezsystems.platformui.hybrid.event_subscriber.component_renderer:
         class: EzSystems\HybridPlatformUi\EventSubscriber\ComponentRendererSubscriber
         arguments:
-            - "@ezsystems.platformui.pjax.request_matcher"
+            - "@ezsystems.platformui.hybrid.request_matcher.admin"
         tags:
             - {name: kernel.event_subscriber}
 

--- a/src/bundle/Resources/views/pjax_layout.html.twig
+++ b/src/bundle/Resources/views/pjax_layout.html.twig
@@ -1,0 +1,15 @@
+<div data-name="title">{% block title %}{{ title|default('') }}{% endblock %}</div>
+
+<div data-name="html">
+    {% block content %}{% endblock %}
+</div>
+
+<ul data-name="notification">
+    {% block notification %}
+        {% set notifications = app.session.flashBag.get("notification") %}
+        {% for notification in notifications %}
+            <li data-state="{{ notification.state }}">{{ notification.message }}</li>
+
+        {% endfor %}
+    {% endblock %}
+</ul>

--- a/src/lib/Http/ResponseMatcherInterface.php
+++ b/src/lib/Http/ResponseMatcherInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\HybridPlatformUi\Http;
+
+use Symfony\Component\HttpFoundation\Response;
+
+interface ResponseMatcherInterface
+{
+    /**
+     * @param $response \Symfony\Component\HttpFoundation\Response
+     * @return bool
+     */
+    public function matches(Response $response);
+}

--- a/src/lib/Pjax/MarkupPjaxResponseMatcher.php
+++ b/src/lib/Pjax/MarkupPjaxResponseMatcher.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\HybridPlatformUi\Pjax;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class MarkupPjaxResponseMatcher implements PjaxResponseMatcher
+{
+    /**
+     * @param $response \Symfony\Component\HttpFoundation\Response
+     *
+     * @return bool
+     */
+    public function matches(Response $response)
+    {
+        return $this->hasPjaxMarkup($response->getContent());
+    }
+
+    private function hasPjaxMarkup($html)
+    {
+        return strpos($html, '<div data-name="html">') !== false;
+    }
+}

--- a/src/lib/Pjax/PjaxResponseMatcher.php
+++ b/src/lib/Pjax/PjaxResponseMatcher.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\HybridPlatformUi\Pjax;
+
+use EzSystems\HybridPlatformUi\Http\ResponseMatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Matches a Pjax Http Response.
+ */
+interface PjaxResponseMatcher extends ResponseMatcherInterface
+{
+    public function matches(Response $response);
+}


### PR DESCRIPTION
> Implements [EZP-27501](http://jira.ez.no/browse/EZP-27501)
> Status: ready for review

Configures `src/bundle/Resources/views/pagelayout.html.twig` as the global pagelayout for the `admin_group` siteaccess group. Core templates that use it, `such as content_edit.html.twig, will be rendered within the PJAX DOM and integrated in the Hybrid UI.

<img width="585" alt="capture d ecran 2017-06-17 a 02 11 09" src="https://user-images.githubusercontent.com/235928/27248324-4d60c152-5302-11e7-8971-6dc58d062144.png">

In addition, adds a `PjaxResponseMatcher`, used to detect PJAX responses by looking for `<div data-name="html">` in the content. It allows to match requests that don't identify by the URI or by the PJAX header.

<img width="731" alt="capture d ecran 2017-06-17 a 02 11 59" src="https://user-images.githubusercontent.com/235928/27248333-63216ee2-5302-11e7-9c58-926f6dd88937.png">

### TODO
- [x] Find a better name for the pagelayout template
- [x] Add specs
- [x] Bonus: set the login pagelayout to pjax
