### PR TITLE
Restricted requirements to PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-    - 5.6
     - 7.0
+    - 7.1
 
 # test only master (+ Pull requests)
 branches:

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": "GPL-2.0",
     "minimum-stability": "stable",
     "require": {
+        "php": "^7.0",
         "ezsystems/platform-ui-bundle": "2.0.x-dev",
         "ezsystems/ezpublish-kernel": " ^6.9@dev",
         "symfony/symfony": "~2.8 | ~3.0",


### PR DESCRIPTION
All of the other eZ Platform 2.0 packages require it as well.
Also removed from the Travis matrix.