### PR TITLE
EZP-27543: Integrate PJAX notification in Hybrid Platform UI App

### DIFF
--- a/spec/Pjax/PjaxResponseMainContentMapperSpec.php
+++ b/spec/Pjax/PjaxResponseMainContentMapperSpec.php
@@ -49,6 +49,65 @@ class PjaxResponseMainContentMapperSpec extends ObjectBehavior
         $this->map($response);
     }
 
+    function it_parses_notifications_and_sets_them_as_the_app_notifications(
+        App $app,
+        Response $response
+    ) {
+        $app->setConfig(Argument::that(function ($value) {
+            return
+                is_array($value) &&
+                isset($value['notifications']) &&
+                count($value['notifications']) === 4;
+        }))->shouldBeCalled();
+
+        $this->map($response);
+    }
+
+    function it_parses_notifications_and_sets_type_timeout_and_content(
+        App $app,
+        Response $response
+    ) {
+        $app->setConfig(Argument::that(function ($value) {
+            $unknown = $value['notifications'][0];
+
+            return
+                $unknown['type'] === 'unknown' &&
+                $unknown['timeout'] === 10 &&
+                $unknown['content'] = 'notification unknown';
+        }))->shouldBeCalled();
+
+        $this->map($response);
+    }
+
+    function it_parses_notifications_and_maps_done_and_processing_state_to_positive_and_processing_type(
+        App $app,
+        Response $response
+    ) {
+        $app->setConfig(Argument::that(function ($value) {
+            $stateDone = $value['notifications'][1];
+            $stateStarted = $value['notifications'][2];
+
+            return
+                $stateDone['type'] === 'positive' &&
+                $stateStarted['type'] === 'processing';
+        }))->shouldBeCalled();
+
+        $this->map($response);
+    }
+
+    function it_parses_notifications_and_sets_timeout_to_0_for_error(
+        App $app,
+        Response $response
+    ) {
+        $app->setConfig(Argument::that(function ($value) {
+            $error = $value['notifications'][3];
+
+            return $error['timeout'] === 0;
+        }))->shouldBeCalled();
+
+        $this->map($response);
+    }
+
     function it_parses_the_content_and_sets_it_as_the_app_MainContent_result(
         App $app,
         Response $response

--- a/spec/Pjax/_fixtures/pjax_response.html
+++ b/spec/Pjax/_fixtures/pjax_response.html
@@ -8,4 +8,9 @@
     <section class="extra-class ez-serverside-content">Server side content</section>
 </div>
 
-<ul data-name="notification">Notifications </ul>
+<ul data-name="notification">
+    <li data-state="unknown">notification unknown</li>
+    <li data-state="done">notification done</li>
+    <li data-state="started">notification started</li>
+    <li data-state="error">notification error</li>
+</ul>

--- a/src/lib/Components/App.php
+++ b/src/lib/Components/App.php
@@ -16,6 +16,8 @@ class App implements Component
 
     protected $title;
 
+    protected $notifications = [];
+
     public function __construct(
         $templating,
         MainContent $content,
@@ -35,6 +37,9 @@ class App implements Component
         }
         if (isset($config['toolbars'])) {
             $this->setToolbarsVisibility($config['toolbars']);
+        }
+        if (isset($config['notifications'])) {
+            $this->notifications = $config['notifications'];
         }
 
         if (isset($config['mainContent']) && $config['mainContent'] instanceof Component) {
@@ -75,6 +80,7 @@ class App implements Component
             'update' => [
                 'properties' => [
                     'pageTitle' => $this->title,
+                    'notifications' => $this->notifications,
                 ],
                 'children' => array_merge(
                     $this->toolbars,

--- a/src/lib/Pjax/PjaxResponseMainContentMapper.php
+++ b/src/lib/Pjax/PjaxResponseMainContentMapper.php
@@ -5,6 +5,7 @@ namespace EzSystems\HybridPlatformUi\Pjax;
 use EzSystems\HybridPlatformUi\Components\App;
 use EzSystems\HybridPlatformUi\Components\MainContent;
 use EzSystems\HybridPlatformUi\Mapper\MainContentMapper;
+use EzSystems\PlatformUIBundle\Notification\Notification;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -16,6 +17,17 @@ class PjaxResponseMainContentMapper implements MainContentMapper
      * @var \EzSystems\HybridPlatformUi\Components\App
      */
     private $app;
+
+    /**
+     * A map of PlatformUIBundle's notification state to Hybrid Platform UI
+     * notification type.
+     *
+     * @const Array
+     */
+    const STATE_TO_TYPE_MAP = [
+        Notification::STATE_STARTED => 'processing',
+        Notification::STATE_DONE => 'positive',
+    ];
 
     public function __construct(App $app)
     {
@@ -50,12 +62,44 @@ class PjaxResponseMainContentMapper implements MainContentMapper
         $xpath = new \DOMXPath($doc);
         $title = $xpath->query('//div[@data-name="title"]')[0]->nodeValue;
         $content = $this->innerHtml($xpath->query('//div[@data-name="html"]')[0]);
+        $notificationElements = $xpath->query('//ul[@data-name="notification"]/li');
 
         $this->app->setConfig([
             'title' => $title,
             'toolbars' => ['discovery' => 1],
             'mainContent' => ['result' => '<ez-server-side-content>' . $content . '</ez-server--side-content>'],
+            'notifications' => $this->buildNotifications($notificationElements),
         ]);
+    }
+
+    /**
+     * Builds an array of notifications for Hybrid Platform UI app from PJAX
+     * Notification HTML elements.
+     *
+     * @param \DOMNodeList $elements
+     * @return array
+     */
+    private function buildNotifications(\DOMNodeList $elements)
+    {
+        $notifications = [];
+
+        foreach ($elements as $element) {
+            $state = $element->getAttribute('data-state');
+            $type = isset(static::STATE_TO_TYPE_MAP[$state]) ? static::STATE_TO_TYPE_MAP[$state] : $state;
+            $timeout = 10;
+
+            if ($type === 'error') {
+                $timeout = 0;
+            }
+
+            $notifications[] = [
+                'type' => $type,
+                'timeout' => $timeout,
+                'content' => $this->innerHtml($element),
+            ];
+        }
+
+        return $notifications;
     }
 
     private function innerHtml(\DOMElement $element)


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27543
Requires: https://github.com/ezsystems/PlatformUIBundle/pull/881

# Description

This patch adds the parsing of the notifications generated in PJAX responses. As result, notifications after actions in the admin panel are back in the interface.

Screencast:

[![](https://img.youtube.com/vi/NsfR1M-wacE/0.jpg)](http://www.youtube.com/watch?v=NsfR1M-wacE "Click to play on Youtube.com")

# Tests

manual test + unit tests