### PR TITLE
Added _wdt to the routes exposed using fos_js_routing

### DIFF
--- a/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
+++ b/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
@@ -34,6 +34,7 @@ class EzSystemsHybridPlatformUiExtension extends Extension implements PrependExt
     public function prepend(ContainerBuilder $container)
     {
         $this->prependViewsConfiguration($container);
+        $this->prependFosJsRoutingConfiguration($container);
     }
 
     private function prependViewsConfiguration(ContainerBuilder $container)
@@ -41,6 +42,14 @@ class EzSystemsHybridPlatformUiExtension extends Extension implements PrependExt
         $configFile = __DIR__ . '/../Resources/config/views.yml';
         $config = Yaml::parse(file_get_contents($configFile));
         $container->prependExtensionConfig('ezpublish', $config);
+        $container->addResource(new FileResource($configFile));
+    }
+
+    private function prependFosJsRoutingConfiguration(ContainerBuilder $container)
+    {
+        $configFile = __DIR__ . '/../Resources/config/fos_js_routing.yml';
+        $config = Yaml::parse(file_get_contents($configFile));
+        $container->prependExtensionConfig('fos_js_routing', $config);
         $container->addResource(new FileResource($configFile));
     }
 }

--- a/src/bundle/Resources/config/fos_js_routing.yml
+++ b/src/bundle/Resources/config/fos_js_routing.yml
@@ -1,0 +1,2 @@
+routes_to_expose:
+    - _wdt


### PR DESCRIPTION
> Relates to [EZP-27359](https://jira.ez.no/browse/EZP-27359)

Prepends `fos_js_routing` configuration for the `_wdt` route (web debug toolbar). This is required by the ajax update of the toolbar.