### PR TITLE
EZP-27448: Display url aliases tab

### DIFF
--- a/src/bundle/Controller/ContentViewController.php
+++ b/src/bundle/Controller/ContentViewController.php
@@ -103,6 +103,18 @@ class ContentViewController extends Controller
         return $view;
     }
 
+    public function urlsTabAction(ContentView $view)
+    {
+        $urlAliasService = $this->getRepository()->getURLAliasService();
+
+        $view->addParameters([
+            'system_urls' => $urlAliasService->listLocationAliases($view->getLocation(), false),
+            'url_aliases' => $urlAliasService->listLocationAliases($view->getLocation()),
+        ]);
+
+        return $view;
+    }
+
     public function translationsTabAction(ContentView $view)
     {
         $view->addParameters([

--- a/src/bundle/Resources/config/views.yml
+++ b/src/bundle/Resources/config/views.yml
@@ -20,6 +20,11 @@ system:
                     template: "EzSystemsHybridPlatformUiBundle:content/tabs:locations.html.twig"
                     controller: 'EzSystems\HybridPlatformUiBundle\Controller\ContentViewController:locationsTabAction'
                     match: true
+            urls_tab:
+                default:
+                    template: "EzSystemsHybridPlatformUiBundle:content/tabs:urls.html.twig"
+                    controller: 'EzSystems\HybridPlatformUiBundle\Controller\ContentViewController:urlsTabAction'
+                    match: true
             translations_tab:
                 default:
                     template: "EzSystemsHybridPlatformUiBundle:content/tabs:translations.html.twig"

--- a/src/bundle/Resources/views/content/tabs/urls.html.twig
+++ b/src/bundle/Resources/views/content/tabs/urls.html.twig
@@ -1,0 +1,13 @@
+{% trans_default_domain "locationview" %}
+
+<div class="ez-list-toolbar">
+    <h2 class="ez-list-toolbar-label">{{ 'locationview.urls.alias.title'|trans()|desc('URL aliases for') }} "{{ ez_content_name(content) }}"</h2>
+</div>
+
+{{ include('@EzSystemsHybridPlatformUi/content/tabs/urls/table.html.twig', {'urls': url_aliases}) }}
+
+<div class="ez-list-toolbar">
+    <h2 class="ez-list-toolbar-label">{{ 'locationview.urls.system.title'|trans()|desc('System URLs') }}</h2>
+</div>
+
+{{ include('@EzSystemsHybridPlatformUi/content/tabs/urls/table.html.twig', {'urls': system_urls}) }}

--- a/src/bundle/Resources/views/content/tabs/urls/table.html.twig
+++ b/src/bundle/Resources/views/content/tabs/urls/table.html.twig
@@ -1,0 +1,34 @@
+{% trans_default_domain "locationview" %}
+
+<table class="ez-table-data">
+    <thead>
+    <tr>
+        <th></th>
+        <th>{{ 'locationview.urls.content'|trans()|desc('Content') }}</th>
+        <th>{{ 'locationview.urls.languagecode'|trans()|desc('Language code') }}</th>
+        <th>{{ 'locationview.urls.type'|trans()|desc('Type') }}</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for alias in urls %}
+        <tr>
+            <td></td>
+            <td>
+                <a href="{{ alias.path }}">{{ alias.path }}</a>
+            </td>
+            <td>
+                {% for languageCode in alias.languageCodes %}
+                    {{ languageCode }}<br>
+                {% endfor %}
+            </td>
+            <td>
+                {% if alias.forward %}
+                    {{ 'locationview.urls.type.301redirect'|trans()|desc('301 Redirect') }}
+                {% else %}
+                    {{ 'locationview.urls.type.invisible'|trans()|desc('Invisible') }}
+                {% endif %}
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>

--- a/src/bundle/Resources/views/locationview.html.twig
+++ b/src/bundle/Resources/views/locationview.html.twig
@@ -14,6 +14,7 @@
             <li class="ez-tabs-label"><a href="#ez-tab-versions">{{ 'tab.versions'|trans|desc('Versions') }}</a></li>
             <li class="ez-tabs-label"><a href="#ez-tab-locations">{{ 'tab.locations'|trans|desc('Locations') }}</a></li>
             <li class="ez-tabs-label"><a href="#ez-tab-relations">{{ 'tab.related.content'|trans|desc('Related content') }}</a></li>
+            <li class="ez-tabs-label"><a href="#ez-tab-urls">{{ 'tab.related.urls'|trans|desc('URLs') }}</a></li>
             <li class="ez-tabs-label"><a href="#ez-tab-translations">{{ 'tab.translations'|trans|desc('Translations') }}</a></li>
         </ul>
 
@@ -43,6 +44,9 @@
             </div>
             <div class="ez-tabs-panel" id="ez-tab-relations">
                 <p>Relation and reverse relation list should be generated here</p>
+            </div>
+            <div class="ez-tabs-panel" id="ez-tab-urls">
+                {{ render(controller('ez_content:viewAction', {'contentId': contentId, 'locationId': locationId, 'viewType': 'urls_tab'})) }}
             </div>
             <div class="ez-tabs-panel" id="ez-tab-translations">
                 {{ render(controller('ez_content:viewAction', {'contentId': contentId, 'locationId': locationId, 'viewType': 'translations_tab'})) }}


### PR DESCRIPTION
- [X] Display system aliases
- [X] Display custom aliases

### Improvement 
Should the blank table be shown if none exist or a message be displayed? 

https://jira.ez.no/browse/EZP-27448

<img width="1036" alt="screen shot 2017-06-27 at 11 54 59" src="https://user-images.githubusercontent.com/2786820/27584341-897c96d6-5b2f-11e7-9778-cfa175496e93.png">
