### PR TITLE
Do not render responses that are redirects.

### DIFF
--- a/spec/EventSubscriber/AppRendererSubscriberSpec.php
+++ b/spec/EventSubscriber/AppRendererSubscriberSpec.php
@@ -39,6 +39,7 @@ class AppRendererSubscriberSpec extends ObjectBehavior
         $event->getRequest()->willReturn($request);
         $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
         $event->getResponse()->willReturn($response);
+        $response->isRedirect()->willReturn(false);
 
         $this->beConstructedWith($app, $renderer, $adminRequestMatcher);
     }
@@ -72,6 +73,17 @@ class AppRendererSubscriberSpec extends ObjectBehavior
     {
         $event->getRequestType()->willReturn(HttpKernelInterface::SUB_REQUEST);
         $event->getRequest()->shouldNotBeCalled();
+        $this->renderApp($event);
+    }
+
+    function it_ignores_redirect_responses(
+        FilterResponseEvent $event,
+        AppResponseRenderer $renderer,
+        Response $response
+    ) {
+        $response->isRedirect()->willReturn(true);
+        $renderer->render(Argument::any())->shouldNotBeCalled();
+
         $this->renderApp($event);
     }
 

--- a/src/lib/EventSubscriber/AppRendererSubscriber.php
+++ b/src/lib/EventSubscriber/AppRendererSubscriber.php
@@ -49,12 +49,18 @@ class AppRendererSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $response = $event->getResponse();
+
+        if ($response->isRedirect()) {
+            return;
+        }
+
         $request = $event->getRequest();
 
         if (!$this->hybridRequestMatcher->matches($request)) {
             return;
         }
 
-        $this->appRenderer->render($event->getResponse(), $this->app);
+        $this->appRenderer->render($response, $this->app);
     }
 }


### PR DESCRIPTION
This fixes the issue where when a redirect response is returned the
app renderer removes the headers and changes the content therefore
causing a white page