### PR TITLE
EZP-27476: app symfony error handling

### DIFF
--- a/spec/App/RequestAppResponseRendererSpec.php
+++ b/spec/App/RequestAppResponseRendererSpec.php
@@ -3,21 +3,81 @@
 namespace spec\EzSystems\HybridPlatformUi\App;
 
 use EzSystems\HybridPlatformUi\App\RequestAppResponseRenderer;
+use EzSystems\HybridPlatformUi\Components\App;
 use EzSystems\HybridPlatformUi\Http\AjaxUpdateRequestMatcher;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
 
 class RequestAppResponseRendererSpec extends ObjectBehavior
 {
     function let(
+        Request $request,
         RequestStack $requestStack,
-        AjaxUpdateRequestMatcher $ajaxUpdateRequestMatcher
+        AjaxUpdateRequestMatcher $ajaxUpdateRequestMatcher,
+        ParameterBag $requestAttributes,
+        HeaderBag $requestHeaders,
+        Response $response
     ) {
+        $request->attributes = $requestAttributes;
+        $response->headers = $requestHeaders;
+        $requestStack->getMasterRequest()->willReturn($request);
         $this->beConstructedWith($requestStack, $ajaxUpdateRequestMatcher);
     }
 
     function it_is_initializable()
     {
         $this->shouldHaveType(RequestAppResponseRenderer::class);
+    }
+
+    function it_sets_the_response_to_the_app_html(
+        AjaxUpdateRequestMatcher $ajaxUpdateRequestMatcher,
+        App $app,
+        HeaderBag $requestHeaders,
+        Request $request,
+        Response $response
+    ) {
+        $ajaxUpdateRequestMatcher->matches($request)
+            ->shouldBeCalled()
+            ->willReturn(false);
+
+        $app->renderToString()
+            ->shouldBeCalled()
+            ->willReturn('html');
+
+        $response->setContent('html')->shouldBeCalled()->willReturn($response);
+        $requestHeaders->replace(Argument::type('array'))->shouldBeCalled();
+
+        $this->render($response, $app);
+    }
+
+    function it_sets_the_response_to_the_app_json(
+        AjaxUpdateRequestMatcher $ajaxUpdateRequestMatcher,
+        App $app,
+        HeaderBag $requestHeaders,
+        Request $request,
+        Response $response
+    ) {
+        $ajaxUpdateRequestMatcher->matches($request)
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $app->jsonSerialize()
+            ->shouldBeCalled()
+            ->willReturn([]);
+
+        $response->setContent('[]')->shouldBeCalled()->willReturn($response);
+        $requestHeaders->replace(Argument::that(
+            function ($headers) {
+                return isset($headers['content-type'][0])
+                    && $headers['content-type'][0] === 'application/json';
+            }
+        ))->shouldBeCalled();
+
+        $this->render($response, $app);
     }
 }

--- a/spec/App/RequestAppResponseRendererSpec.php
+++ b/spec/App/RequestAppResponseRendererSpec.php
@@ -5,15 +5,15 @@ namespace spec\EzSystems\HybridPlatformUi\App;
 use EzSystems\HybridPlatformUi\App\RequestAppResponseRenderer;
 use EzSystems\HybridPlatformUi\Http\AjaxUpdateRequestMatcher;
 use PhpSpec\ObjectBehavior;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class RequestAppResponseRendererSpec extends ObjectBehavior
 {
     function let(
-        Request $request,
+        RequestStack $requestStack,
         AjaxUpdateRequestMatcher $ajaxUpdateRequestMatcher
     ) {
-        $this->beConstructedWith($request, $ajaxUpdateRequestMatcher);
+        $this->beConstructedWith($requestStack, $ajaxUpdateRequestMatcher);
     }
 
     function it_is_initializable()

--- a/spec/App/ToolbarsConfigurator/RouteToolbarsConfiguratorSpec.php
+++ b/spec/App/ToolbarsConfigurator/RouteToolbarsConfiguratorSpec.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace spec\EzSystems\HybridPlatformUi\App\ToolbarsConfigurator;
+
+use EzSystems\HybridPlatformUi\App\ToolbarsConfigurator\RouteToolbarsConfigurator;
+use EzSystems\HybridPlatformUi\App\ToolbarsConfigurator;
+use EzSystems\HybridPlatformUi\Components\App;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class RouteToolbarsConfiguratorSpec extends ObjectBehavior
+{
+    public function let(
+        ParameterBag $requestAttributes,
+        RequestStack $requestStack,
+        Request $request
+    ) {
+        $request->attributes = $requestAttributes;
+        $requestStack->getMasterRequest()->willReturn($request);
+
+        $this->beConstructedWith($requestStack);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(RouteToolbarsConfigurator::class);
+        $this->shouldHaveType(ToolbarsConfigurator::class);
+    }
+
+    function it_enables_the_discovery_bar_for_ezurlalias(
+        App $app,
+        ParameterBag $requestAttributes
+    ) {
+        $requestAttributes->get('_route')->shouldBeCalled()->willReturn('ez_urlalias');
+        $app->setConfig(Argument::that(
+            function ($config) {
+                return isset($config['toolbars'])
+                    && $config['toolbars'] == ['discovery' => 1];
+            }
+        ))->shouldBeCalled();
+
+        $this->configureToolbars($app);
+    }
+
+    function it_does_not_enable_any_toolbar_for_unknown_routes(
+        App $app,
+        ParameterBag $requestAttributes
+    ) {
+        $requestAttributes->get('_route')->shouldBeCalled()->willReturn('someroute');
+        $app->setConfig(Argument::any())->shouldNotBeCalled();
+
+        $this->configureToolbars($app);
+    }
+}

--- a/spec/Components/NotificationsSpec.php
+++ b/spec/Components/NotificationsSpec.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\Components;
+
+use EzSystems\HybridPlatformUi\Components\Notifications;
+use EzSystems\HybridPlatformUi\Components\Component;
+use EzSystems\HybridPlatformUi\Notification\Notification;
+use EzSystems\HybridPlatformUi\Notification\NotificationPool;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Templating\EngineInterface;
+
+class NotificationsSpec extends ObjectBehavior
+{
+    function let(EngineInterface $templating, NotificationPool $notificationPool)
+    {
+        $this->beConstructedWith($templating, $notificationPool);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(Notifications::class);
+    }
+
+    function it_is_a_component()
+    {
+        $this->shouldHaveType(Component::class);
+    }
+
+    function it_has_an_exception_property()
+    {
+        $this->exception = new Notification();
+    }
+
+    function it_renders_notifications_from_the_pool_to_a_string(
+        EngineInterface $templating,
+        NotificationPool $notificationPool
+    ) {
+        $notification = new Notification([
+            'message' => 'the message',
+            'timeout' => 0,
+            'copyable' => true,
+            'details' => 'details',
+        ]);
+        $notificationPool->get()
+            ->shouldBeCalled()
+            ->willReturn([$notification]);
+        $templating->render(Notifications::NOTIFICATION_TEMPLATE, ['notification' => $notification])
+            ->shouldBeCalled()
+            ->willReturn('<ez-notification />');
+        $this->renderToString()->shouldBe('<ez-notification />');
+    }
+
+    function it_renders_notifications_from_the_pool_to_json(
+        NotificationPool $notificationPool
+    ) {
+        $notification = new Notification(['message' => 'the message']);
+
+        $notificationPool->get()
+            ->shouldBeCalled()
+            ->willReturn([$notification]);
+        $this->jsonSerialize()->shouldBe([[
+            'type' => null,
+            'content' => 'the message',
+            'timeout' => 10,
+            'details' => null,
+            'copyable' => null,
+        ]]);
+    }
+
+    function it_renders_the_exception_to_json_if_there_is_one(
+        EngineInterface $templating,
+        NotificationPool $notificationPool
+    ) {
+        $notificationPool->get()->shouldNotBeCalled();
+        $this->exception = new Notification(['type' => 'error']);
+
+        $this->jsonSerialize()->shouldBeArrayOfNotifications([$this->exception]);
+    }
+
+    function getMatchers()
+    {
+        return [
+            'beArrayOfNotifications' => function ($array, $notifications): bool {
+                foreach ($notifications as $index => $notification) {
+                    if (!isset($array[$index])) {
+                        return false;
+                    }
+
+                    $testedNotification = $array[$index];
+                    if (!array_key_exists('type', $testedNotification) || $testedNotification['type'] != $notification->type) {
+                        return false;
+                    }
+                    if (!array_key_exists('copyable', $testedNotification) || $testedNotification['copyable'] != $notification->copyable) {
+                        return false;
+                    }
+                    if (!array_key_exists('content', $testedNotification) || $testedNotification['content'] != $notification->message) {
+                        return false;
+                    }
+                    if (!array_key_exists('details', $testedNotification) || $testedNotification['details'] != $notification->details) {
+                        return false;
+                    }
+                    if (!array_key_exists('timeout', $testedNotification) || $testedNotification['timeout'] != $notification->timeout) {
+                        return false;
+                    }
+
+                    return true;
+                }
+            },
+        ];
+    }
+}

--- a/spec/Components/NotificationsSpec.php
+++ b/spec/Components/NotificationsSpec.php
@@ -36,7 +36,7 @@ class NotificationsSpec extends ObjectBehavior
         NotificationPool $notificationPool
     ) {
         $notification = new Notification([
-            'message' => 'the message',
+            'content' => 'the message',
             'timeout' => 0,
             'copyable' => true,
             'details' => 'details',
@@ -53,7 +53,7 @@ class NotificationsSpec extends ObjectBehavior
     function it_renders_notifications_from_the_pool_to_json(
         NotificationPool $notificationPool
     ) {
-        $notification = new Notification(['message' => 'the message']);
+        $notification = new Notification(['content' => 'the message']);
 
         $notificationPool->get()
             ->shouldBeCalled()
@@ -87,20 +87,13 @@ class NotificationsSpec extends ObjectBehavior
                     }
 
                     $testedNotification = $array[$index];
-                    if (!array_key_exists('type', $testedNotification) || $testedNotification['type'] != $notification->type) {
-                        return false;
-                    }
-                    if (!array_key_exists('copyable', $testedNotification) || $testedNotification['copyable'] != $notification->copyable) {
-                        return false;
-                    }
-                    if (!array_key_exists('content', $testedNotification) || $testedNotification['content'] != $notification->message) {
-                        return false;
-                    }
-                    if (!array_key_exists('details', $testedNotification) || $testedNotification['details'] != $notification->details) {
-                        return false;
-                    }
-                    if (!array_key_exists('timeout', $testedNotification) || $testedNotification['timeout'] != $notification->timeout) {
-                        return false;
+                    foreach (['type', 'content', 'details', 'timeout', 'copyable'] as $property) {
+                        if (!array_key_exists($property, $testedNotification)) {
+                            return false;
+                        }
+                        if ($testedNotification[$property] != $notification->$property) {
+                            return false;
+                        }
                     }
 
                     return true;

--- a/spec/EventSubscriber/AppRendererSubscriberSpec.php
+++ b/spec/EventSubscriber/AppRendererSubscriberSpec.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -39,8 +38,8 @@ class AppRendererSubscriberSpec extends ObjectBehavior
         $request->duplicate(Argument::cetera())->willReturn(new Request());
 
         $event->getRequest()->willReturn($request);
-        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
         $event->getResponse()->willReturn($response);
+        $event->isMasterRequest()->willReturn(true);
         $response->isRedirect()->willReturn(false);
 
         $this->beConstructedWith($app, $renderer, $hybridRequestMatcher);
@@ -73,7 +72,7 @@ class AppRendererSubscriberSpec extends ObjectBehavior
 
     function it_ignores_sub_requests(FilterResponseEvent $event)
     {
-        $event->getRequestType()->willReturn(HttpKernelInterface::SUB_REQUEST);
+        $event->isMasterRequest()->willReturn(false);
         $event->getRequest()->shouldNotBeCalled();
         $this->renderApp($event);
     }

--- a/spec/EventSubscriber/AppRendererSubscriberSpec.php
+++ b/spec/EventSubscriber/AppRendererSubscriberSpec.php
@@ -3,6 +3,7 @@
 namespace spec\EzSystems\HybridPlatformUi\EventSubscriber;
 
 use EzSystems\HybridPlatformUi\App\AppResponseRenderer;
+use EzSystems\HybridPlatformUi\App\ToolbarsConfigurator;
 use EzSystems\HybridPlatformUi\Components\App;
 use EzSystems\HybridPlatformUi\EventSubscriber\AppRendererSubscriber;
 use EzSystems\HybridPlatformUi\Http\HybridRequestMatcher;
@@ -31,7 +32,8 @@ class AppRendererSubscriberSpec extends ObjectBehavior
         Request $request,
         Response $response,
         ParameterBag $requestAttributes,
-        HybridRequestMatcher $hybridRequestMatcher
+        HybridRequestMatcher $hybridRequestMatcher,
+        ToolbarsConfigurator $toolbarsConfigurator
     ) {
         $hybridRequestMatcher->matches(Argument::type(Request::class))->willReturn(true);
         $request->attributes = $requestAttributes;
@@ -42,7 +44,7 @@ class AppRendererSubscriberSpec extends ObjectBehavior
         $event->isMasterRequest()->willReturn(true);
         $response->isRedirect()->willReturn(false);
 
-        $this->beConstructedWith($app, $renderer, $hybridRequestMatcher);
+        $this->beConstructedWith($app, $renderer, $hybridRequestMatcher, $toolbarsConfigurator);
     }
 
     function it_is_initializable()
@@ -110,12 +112,14 @@ class AppRendererSubscriberSpec extends ObjectBehavior
         $this->renderApp($event);
     }
 
-    function it_renders_the_app(
+    function it_configures_the_toolbars_and_renders_the_app(
         App $app,
         AppResponseRenderer $renderer,
-        FilterResponseEvent $event
+        FilterResponseEvent $event,
+        ToolbarsConfigurator $toolbarsConfigurator
     ) {
         $renderer->render(Argument::type(Response::class), $app)->shouldBeCalled();
+        $toolbarsConfigurator->configureToolbars($app)->shouldBeCalled();
 
         $this->renderApp($event);
     }

--- a/spec/EventSubscriber/PjaxSubscriberSpec.php
+++ b/spec/EventSubscriber/PjaxSubscriberSpec.php
@@ -31,6 +31,9 @@ class PjaxSubscriberSpec extends ObjectBehavior
         $event->getResponse()->willReturn($response);
         $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
 
+        $response->isClientError()->willReturn(false);
+        $response->isServerError()->willReturn(false);
+
         $adminRequestMatcher->matches($request)->willReturn(true);
         $pjaxRequestMatcher->matches($request)->willReturn(true);
 
@@ -41,6 +44,27 @@ class PjaxSubscriberSpec extends ObjectBehavior
     {
         $this->shouldHaveType(PjaxSubscriber::class);
         $this->shouldHaveType(EventSubscriberInterface::class);
+    }
+
+    function it_ignores_responses_that_are_client_errors(
+        FilterResponseEvent $event,
+        PjaxResponseMainContentMapper $mapper,
+        Response $response
+    ) {
+        $response->isClientError()->shouldBeCalled()->willReturn(true);
+        $mapper->map($response)->shouldNotBeCalled();
+
+        $this->mapPjaxResponseToMainContent($event);
+    }
+
+    function it_ignores_responses_that_are_server_errors(
+        FilterResponseEvent $event,
+        PjaxResponseMainContentMapper $mapper,
+        Response $response
+    ) {
+        $response->isServerError()->shouldBeCalled()->willReturn(true);
+        $mapper->map($response)->shouldNotBeCalled();
+        $this->mapPjaxResponseToMainContent($event);
     }
 
     function it_ignores_sub_requests(FilterResponseEvent $event)

--- a/spec/Http/Response/NotificationResponseSpec.php
+++ b/spec/Http/Response/NotificationResponseSpec.php
@@ -17,14 +17,14 @@ class NotificationResponseSpec extends ObjectBehavior
 
     private $timeout = Notification::DEFAULT_TIMEOUT;
 
-    private $message = 'test message';
+    private $content = 'test message';
 
     function let()
     {
         $notification = new Notification([
             'type' => $this->type,
             'timeout' => $this->timeout,
-            'message' => $this->message,
+            'content' => $this->content,
         ]);
 
         $this->beConstructedWith($notification);
@@ -43,7 +43,7 @@ class NotificationResponseSpec extends ObjectBehavior
     function it_converts_notification_to_string()
     {
         $this->getContent()->shouldBe(
-            '<ez-notification type="' . $this->type . '" timeout="' . $this->timeout . '">' . $this->message . '</ez-notification>'
+            '<ez-notification type="' . $this->type . '" timeout="' . $this->timeout . '">' . $this->content . '</ez-notification>'
         );
     }
 }

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -51,7 +51,8 @@ services:
     EzSystems\HybridPlatformUi\App\AppResponseRenderer:
         alias: EzSystems\HybridPlatformUi\App\RequestAppResponseRenderer
 
-    EzSystems\HybridPlatformUi\App\RequestAppResponseRenderer: ~
+    EzSystems\HybridPlatformUi\App\ToolbarsConfigurator:
+        alias: 'EzSystems\HybridPlatformUi\App\ToolbarsConfigurator\RouteToolbarsConfigurator'
 
     EzSystems\HybridPlatformUi\Http\HtmlFormatRequestMatcher:
         alias: EzSystems\HybridPlatformUi\Http\FormatAttributeHtmlFormatRequestMatcher

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -45,9 +45,7 @@ services:
     EzSystems\HybridPlatformUi\App\AppResponseRenderer:
         alias: EzSystems\HybridPlatformUi\App\RequestAppResponseRenderer
 
-    EzSystems\HybridPlatformUi\App\RequestAppResponseRenderer:
-        arguments:
-            - '@=service("request_stack").getMasterRequest()'
+    EzSystems\HybridPlatformUi\App\RequestAppResponseRenderer: ~
 
     EzSystems\HybridPlatformUi\Http\HtmlFormatRequestMatcher:
         alias: EzSystems\HybridPlatformUi\Http\FormatAttributeHtmlFormatRequestMatcher

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -28,8 +28,14 @@ services:
 
     EzSystems\HybridPlatformUi\EventSubscriber\:
         resource: '../../../lib/EventSubscriber'
+        exclude: '../../../lib/EventSubscriber/AppExceptionSubscriber.php'
         public: true
         tags: ['kernel.event_subscriber']
+
+    EzSystems\HybridPlatformUi\EventSubscriber\AppExceptionSubscriber:
+        decorates: 'twig.exception_listener'
+        arguments:
+            $innerListener: '@EzSystems\HybridPlatformUi\EventSubscriber\AppExceptionSubscriber.inner'
 
     EzSystems\HybridPlatformUi\EventSubscriber\PjaxSubscriber:
         arguments:

--- a/src/bundle/Resources/views/components/app.html.twig
+++ b/src/bundle/Resources/views/components/app.html.twig
@@ -4,19 +4,19 @@
 <{{ tagName }}>
 
 {% block navigationHub %}
-    {{ navigationHub|raw }}
+    {{ navigationHub.renderToString|raw }}
 {% endblock %}
 
 <div id="app-content">
     {% block toolbars %}
         {% for toolbar in toolbars %}
-            {{ toolbar|raw }}
+            {{ toolbar.renderToString|raw }}
         {% endfor %}
     {% endblock %}
 
     <main>
         {% block mainContent %}
-            {{ mainContent|raw }}
+            {{ mainContent.renderToString|raw }}
         {% endblock %}
     </main>
 </div>

--- a/src/bundle/Resources/views/components/navigationhub.html.twig
+++ b/src/bundle/Resources/views/components/navigationhub.html.twig
@@ -13,7 +13,7 @@
         <ul class="ez-navigation">
         {% for link in links %}
         <li data-zone="{{ link.zone }}" class="ez-zone-link {% if link.match(app.request) %} {{ matchedLinkClass }}{% endif %}">
-            {{ link|raw }}
+            {{ link.renderToString|raw }}
         </li>
         {% endfor %}
         </ul>

--- a/src/bundle/Resources/views/components/notification.html.twig
+++ b/src/bundle/Resources/views/components/notification.html.twig
@@ -1,0 +1,8 @@
+{% spaceless %}
+<ez-notification type="{{ notification.type }}"
+                 timeout="{{ notification.timeout }}"
+                 {% if notification.copyable %}copyable{% endif %}
+                 details="{{ notification.details }}">
+{% endspaceless %}
+    {{ notification.message }}
+</ez-notification>

--- a/src/lib/App/AppExceptionConfigurator.php
+++ b/src/lib/App/AppExceptionConfigurator.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\HybridPlatformUi\App;
+
+use Exception;
+use EzSystems\HybridPlatformUi\Components\App;
+use Symfony\Component\HttpFoundation\Response;
+
+class AppExceptionConfigurator implements ExceptionConfigurator
+{
+    /**
+     * @var \EzSystems\HybridPlatformUi\Components\App
+     */
+    private $app;
+
+    public function __construct(App $app)
+    {
+        $this->app = $app;
+    }
+
+    public function configureException(Exception $exception, Response $exceptionResponse)
+    {
+        $this->app->setConfig([
+            'title' => $exception->getMessage(),
+            'exception' => [$this->buildNotification($exception)],
+            'mainContent' => ['result' => $exceptionResponse->getContent()],
+        ]);
+    }
+
+    private function buildNotification(Exception $exception)
+    {
+        return [
+            'type' => 'error',
+            'timeout' => 0,
+            'content' => $exception->getMessage(),
+            'details' => (string)$exception,
+            'copyable' => true,
+        ];
+    }
+}

--- a/src/lib/App/AppExceptionConfigurator.php
+++ b/src/lib/App/AppExceptionConfigurator.php
@@ -36,7 +36,7 @@ class AppExceptionConfigurator implements ExceptionConfigurator
         return new Notification([
             'type' => 'error',
             'timeout' => 0,
-            'message' => $exception->getMessage(),
+            'content' => $exception->getMessage(),
             'details' => (string)$exception,
             'copyable' => true,
         ]);

--- a/src/lib/App/AppExceptionConfigurator.php
+++ b/src/lib/App/AppExceptionConfigurator.php
@@ -8,6 +8,7 @@ namespace EzSystems\HybridPlatformUi\App;
 
 use Exception;
 use EzSystems\HybridPlatformUi\Components\App;
+use EzSystems\HybridPlatformUi\Notification\Notification;
 use Symfony\Component\HttpFoundation\Response;
 
 class AppExceptionConfigurator implements ExceptionConfigurator
@@ -26,19 +27,18 @@ class AppExceptionConfigurator implements ExceptionConfigurator
     {
         $this->app->setConfig([
             'title' => $exception->getMessage(),
-            'exception' => [$this->buildNotification($exception)],
-            'mainContent' => ['result' => $exceptionResponse->getContent()],
+            'exception' => $this->buildNotification($exception),
         ]);
     }
 
     private function buildNotification(Exception $exception)
     {
-        return [
+        return new Notification([
             'type' => 'error',
             'timeout' => 0,
-            'content' => $exception->getMessage(),
+            'message' => $exception->getMessage(),
             'details' => (string)$exception,
             'copyable' => true,
-        ];
+        ]);
     }
 }

--- a/src/lib/App/ExceptionConfigurator.php
+++ b/src/lib/App/ExceptionConfigurator.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\HybridPlatformUi\App;
+
+use Symfony\Component\HttpFoundation\Response;
+use Exception;
+
+/**
+ * Configures the app with an exception.
+ */
+interface ExceptionConfigurator
+{
+    public function configureException(Exception $exception, Response $exceptionResponse);
+}

--- a/src/lib/App/RequestAppResponseRenderer.php
+++ b/src/lib/App/RequestAppResponseRenderer.php
@@ -8,15 +8,15 @@ namespace EzSystems\HybridPlatformUi\App;
 use EzSystems\HybridPlatformUi\Components\App;
 use EzSystems\HybridPlatformUi\Http\AjaxUpdateRequestMatcher;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
 class RequestAppResponseRenderer implements AppResponseRenderer
 {
     /**
-     * @var \Symfony\Component\HttpFoundation\Request
+     * @var \Symfony\Component\HttpFoundation\RequestStack
      */
-    private $request;
+    private $requestStack;
 
     /**
      * @var \Symfony\Component\HttpFoundation\RequestMatcherInterface
@@ -24,10 +24,10 @@ class RequestAppResponseRenderer implements AppResponseRenderer
     private $ajaxUpdateRequestMatcher;
 
     public function __construct(
-        Request $request,
+        RequestStack $requestStack,
         AjaxUpdateRequestMatcher $ajaxUpdateRequestMatcher
     ) {
-        $this->request = $request;
+        $this->requestStack = $requestStack;
         $this->ajaxUpdateRequestMatcher = $ajaxUpdateRequestMatcher;
     }
 
@@ -35,7 +35,7 @@ class RequestAppResponseRenderer implements AppResponseRenderer
     {
         $this->configureToolbars($app);
 
-        $appResponse = $this->ajaxUpdateRequestMatcher->matches($this->request)
+        $appResponse = $this->ajaxUpdateRequestMatcher->matches($this->requestStack->getCurrentRequest())
             ? new JsonResponse($app)
             : new Response($app->renderToString());
 

--- a/src/lib/App/RequestAppResponseRenderer.php
+++ b/src/lib/App/RequestAppResponseRenderer.php
@@ -35,13 +35,20 @@ class RequestAppResponseRenderer implements AppResponseRenderer
     {
         $this->configureToolbars($app);
 
-        $appResponse = $this->ajaxUpdateRequestMatcher->matches($this->requestStack->getCurrentRequest())
+        $appResponse = $this->isUpdateRequest()
             ? new JsonResponse($app)
             : new Response($app->renderToString());
 
         $response
             ->setContent($appResponse->getContent())
             ->headers->replace($appResponse->headers->all());
+    }
+
+    private function isUpdateRequest()
+    {
+        return $this->ajaxUpdateRequestMatcher->matches(
+            $this->requestStack->getMasterRequest()
+        );
     }
 
     /**
@@ -51,6 +58,11 @@ class RequestAppResponseRenderer implements AppResponseRenderer
      */
     private function configureToolbars(App $app)
     {
-        $app->setConfig(['toolbars' => ['discovery' => 1]]);
+        $config = ['discovery' => 0];
+        if ($this->requestStack->getMasterRequest()->attributes->get('_route') === 'ez_urlalias') {
+            $config = ['discovery' => 1];
+        }
+
+        $app->setConfig(['toolbars' => $config]);
     }
 }

--- a/src/lib/App/RequestAppResponseRenderer.php
+++ b/src/lib/App/RequestAppResponseRenderer.php
@@ -33,8 +33,6 @@ class RequestAppResponseRenderer implements AppResponseRenderer
 
     public function render(Response $response, App $app)
     {
-        $this->configureToolbars($app);
-
         $appResponse = $this->isUpdateRequest()
             ? new JsonResponse($app)
             : new Response($app->renderToString());
@@ -49,20 +47,5 @@ class RequestAppResponseRenderer implements AppResponseRenderer
         return $this->ajaxUpdateRequestMatcher->matches(
             $this->requestStack->getMasterRequest()
         );
-    }
-
-    /**
-     * Configures the toolbars.
-     *
-     * @todo Depends on the Request. See http://github.com/ezsystems/hybrid-platform-ui/pull/4
-     */
-    private function configureToolbars(App $app)
-    {
-        $config = ['discovery' => 0];
-        if ($this->requestStack->getMasterRequest()->attributes->get('_route') === 'ez_urlalias') {
-            $config = ['discovery' => 1];
-        }
-
-        $app->setConfig(['toolbars' => $config]);
     }
 }

--- a/src/lib/App/RequestAppResponseRenderer.php
+++ b/src/lib/App/RequestAppResponseRenderer.php
@@ -37,7 +37,7 @@ class RequestAppResponseRenderer implements AppResponseRenderer
 
         $appResponse = $this->ajaxUpdateRequestMatcher->matches($this->request)
             ? new JsonResponse($app)
-            : new Response($app);
+            : new Response($app->renderToString());
 
         $response
             ->setContent($appResponse->getContent())

--- a/src/lib/App/ToolbarsConfigurator.php
+++ b/src/lib/App/ToolbarsConfigurator.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\HybridPlatformUi\App;
+
+use EzSystems\HybridPlatformUi\Components\App;
+
+/**
+ * Configures the App's toolbars.
+ */
+interface ToolbarsConfigurator
+{
+    public function configureToolbars(App $app);
+}

--- a/src/lib/App/ToolbarsConfigurator/RouteToolbarsConfigurator.php
+++ b/src/lib/App/ToolbarsConfigurator/RouteToolbarsConfigurator.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\HybridPlatformUi\App\ToolbarsConfigurator;
+
+use EzSystems\HybridPlatformUi\App\ToolbarsConfigurator;
+use EzSystems\HybridPlatformUi\Components\App;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class RouteToolbarsConfigurator implements ToolbarsConfigurator
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestStack
+     */
+    private $requestStack;
+
+    protected $routesConfiguration = [
+        'ez_urlalias' => ['discovery' => 1],
+    ];
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public function configureToolbars(App $app)
+    {
+        $route = $this->requestStack->getMasterRequest()->attributes->get('_route');
+
+        if (isset($this->routesConfiguration[$route])) {
+            $app->setConfig(['toolbars' => $this->routesConfiguration[$route]]);
+        }
+    }
+}

--- a/src/lib/Components/App.php
+++ b/src/lib/Components/App.php
@@ -61,7 +61,7 @@ class App implements Component
         }
     }
 
-    public function __toString()
+    public function renderToString()
     {
         return $this->templating->render(
             'EzSystemsHybridPlatformUiBundle:components:app.html.twig',

--- a/src/lib/Components/App.php
+++ b/src/lib/Components/App.php
@@ -2,6 +2,7 @@
 
 namespace EzSystems\HybridPlatformUi\Components;
 
+use EzSystems\HybridPlatformUi\Notification\Notification;
 use Symfony\Component\Templating\EngineInterface;
 
 class App implements Component
@@ -18,7 +19,10 @@ class App implements Component
 
     protected $title;
 
-    protected $notifications = [];
+    /**
+     * @var \EzSystems\HybridPlatformUi\Components\Notifications
+     */
+    protected $notifications;
 
     /**
      * General app exception. If set, the exception alone is rendered, without any
@@ -32,12 +36,14 @@ class App implements Component
         EngineInterface $templating,
         MainContent $content,
         NavigationHub $navigationHub,
-        array $toolbars
+        array $toolbars,
+        Notifications $notifications
     ) {
         $this->templating = $templating;
         $this->mainContent = $content;
         $this->navigationHub = $navigationHub;
         $this->toolbars = $toolbars;
+        $this->notifications = $notifications;
     }
 
     public function setConfig(array $config)
@@ -45,14 +51,13 @@ class App implements Component
         if (isset($config['title'])) {
             $this->title = $config['title'];
         }
+
         if (isset($config['toolbars'])) {
             $this->setToolbarsVisibility($config['toolbars']);
         }
-        if (isset($config['notifications'])) {
-            $this->notifications = $config['notifications'];
-        }
+
         if (isset($config['exception'])) {
-            $this->exception = $config['exception'];
+            $this->notifications->exception = $config['exception'];
         }
 
         if (isset($config['mainContent']) && $config['mainContent'] instanceof Component) {
@@ -93,7 +98,7 @@ class App implements Component
     public function jsonSerialize()
     {
         if ($this->isException()) {
-            $update = ['properties' => ['notifications' => $this->exception]];
+            $update = ['properties' => ['notifications' => $this->notifications]];
         } else {
             $update = [
                 'properties' => [
@@ -115,6 +120,6 @@ class App implements Component
 
     private function isException()
     {
-        return $this->exception !== null;
+        return $this->notifications->exception instanceof Notification;
     }
 }

--- a/src/lib/Components/Browse.php
+++ b/src/lib/Components/Browse.php
@@ -25,7 +25,7 @@ class Browse implements Component
         return null;
     }
 
-    public function __toString()
+    public function renderToString()
     {
         $selected = $this->getLocationId();
         // should be rendered with a twig template

--- a/src/lib/Components/Browse.php
+++ b/src/lib/Components/Browse.php
@@ -11,7 +11,7 @@ class Browse implements Component
      */
     protected $request;
 
-    public function __construct(Request $request)
+    public function __construct(Request $request = null)
     {
         $this->request = $request;
     }

--- a/src/lib/Components/Component.php
+++ b/src/lib/Components/Component.php
@@ -4,5 +4,5 @@ namespace EzSystems\HybridPlatformUi\Components;
 
 interface Component extends \JsonSerializable
 {
-    public function __toString();
+    function renderToString();
 }

--- a/src/lib/Components/MainContent.php
+++ b/src/lib/Components/MainContent.php
@@ -34,7 +34,7 @@ class MainContent implements Component
         $this->result = $result;
     }
 
-    public function __toString()
+    public function renderToString()
     {
         $string = '';
         if ($this->result) {
@@ -53,7 +53,7 @@ class MainContent implements Component
     {
         return [
             'selector' => 'main',
-            'update' => (string)$this,
+            'update' => $this->renderToString(),
         ];
     }
 }

--- a/src/lib/Components/NavigationHub.php
+++ b/src/lib/Components/NavigationHub.php
@@ -33,7 +33,7 @@ class NavigationHub implements Component
      */
     protected $request;
 
-    public function __construct(EngineInterface $templating, Request $request, array $zones = [], array $links = [])
+    public function __construct(EngineInterface $templating, Request $request = null, array $zones = [], array $links = [])
     {
         $this->request = $request;
         $this->templating = $templating;

--- a/src/lib/Components/NavigationHub.php
+++ b/src/lib/Components/NavigationHub.php
@@ -41,7 +41,7 @@ class NavigationHub implements Component
         $this->links = $links;
     }
 
-    public function __toString()
+    public function renderToString()
     {
         return $this->templating->render(
             'EzSystemsHybridPlatformUiBundle:components:navigationhub.html.twig',

--- a/src/lib/Components/Notifications.php
+++ b/src/lib/Components/Notifications.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\HybridPlatformUi\Components;
+
+use EzSystems\HybridPlatformUi\Notification\Notification;
+use EzSystems\HybridPlatformUi\Notification\NotificationPool;
+use Symfony\Component\Templating\EngineInterface;
+
+class Notifications implements Component
+{
+    const NOTIFICATION_TEMPLATE = 'EzSystemsHybridPlatformUiBundle:components:notification.html.twig';
+
+    public $exception = null;
+
+    /**
+     * @var \Symfony\Component\Templating\EngineInterface
+     */
+    private $templating;
+
+    /**
+     * @var \EzSystems\HybridPlatformUi\Notification\NotificationPool
+     */
+    private $notificationPool;
+
+    public function __construct(EngineInterface $templating, NotificationPool $notificationPool)
+    {
+        $this->templating = $templating;
+        $this->notificationPool = $notificationPool;
+    }
+
+    function renderToString()
+    {
+        $html = '';
+        foreach ($this->notificationPool->get() as $notification) {
+            $html .= $this->notificationToHtml($notification);
+        }
+
+        return $html;
+    }
+
+    /**
+     * Notifications are not serialized to JSON updates.
+     */
+    function jsonSerialize()
+    {
+        return array_map(
+            function (Notification $notification) {
+                return [
+                    'type' => $notification->type,
+                    'content' => $notification->message,
+                    'timeout' => $notification->timeout,
+                    'details' => $notification->details,
+                    'copyable' => $notification->copyable,
+                ];
+            },
+            $this->isException() ? [$this->exception] : $this->notificationPool->get()
+        );
+    }
+
+    private function notificationToHtml(Notification $notification)
+    {
+        return $this->templating->render(
+            self::NOTIFICATION_TEMPLATE,
+            ['notification' => $notification]
+        );
+    }
+
+    /**
+     * @return bool
+     */
+    private function isException()
+    {
+        return $this->exception instanceof Notification;
+    }
+}

--- a/src/lib/Components/Notifications.php
+++ b/src/lib/Components/Notifications.php
@@ -51,7 +51,7 @@ class Notifications implements Component
             function (Notification $notification) {
                 return [
                     'type' => $notification->type,
-                    'content' => $notification->message,
+                    'content' => $notification->content,
                     'timeout' => $notification->timeout,
                     'details' => $notification->details,
                     'copyable' => $notification->copyable,

--- a/src/lib/Components/Search.php
+++ b/src/lib/Components/Search.php
@@ -4,7 +4,7 @@ namespace EzSystems\HybridPlatformUi\Components;
 
 class Search implements Component
 {
-    public function __toString()
+    public function renderToString()
     {
         return '<button class="ez-button" disabled>Search</button>';
     }

--- a/src/lib/Components/Toolbar.php
+++ b/src/lib/Components/Toolbar.php
@@ -16,11 +16,11 @@ class Toolbar implements Component
         $this->children = $children;
     }
 
-    public function __toString()
+    public function renderToString()
     {
         $html = '<ez-toolbar id="' . $this->id . '"' . ($this->visible ? ' visible' : '') . '>';
         foreach ($this->children as $component) {
-            $html .= (string)$component;
+            $html .= $component->renderToString();
         }
         $html .= '</ez-toolbar>';
 

--- a/src/lib/Components/Trash.php
+++ b/src/lib/Components/Trash.php
@@ -4,7 +4,7 @@ namespace EzSystems\HybridPlatformUi\Components;
 
 class Trash implements Component
 {
-    public function __toString()
+    public function renderToString()
     {
         return '<button class="ez-button" disabled>
             Trash

--- a/src/lib/EventSubscriber/AppExceptionSubscriber.php
+++ b/src/lib/EventSubscriber/AppExceptionSubscriber.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\HybridPlatformUi\EventSubscriber;
+
+use EzSystems\HybridPlatformUi\App\ExceptionConfigurator;
+use EzSystems\HybridPlatformUi\Http\HybridRequestMatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
+
+/**
+ * Overrides the HttpKernel Exception subscriber for hybrid UI requests.
+ */
+class AppExceptionSubscriber extends ExceptionListener implements EventSubscriberInterface
+{
+    /**
+     * @var \Symfony\Component\HttpKernel\EventListener\ExceptionListener
+     */
+    private $innerListener;
+    /**
+     * @var \EzSystems\HybridPlatformUi\Http\HybridRequestMatcher
+     */
+    private $hybridRequestMatcher;
+
+    /**
+     * @var \EzSystems\HybridPlatformUi\App\ExceptionConfigurator
+     */
+    private $configurator;
+
+    /**
+     * AppExceptionSubscriber constructor.
+     *
+     * @param \Symfony\Component\HttpKernel\EventListener\ExceptionListener $innerListener
+     * @param \EzSystems\HybridPlatformUi\Http\HybridRequestMatcher $hybridRequestMatcher
+     * @param \EzSystems\HybridPlatformUi\App\ExceptionConfigurator $exceptionConfigurator
+     */
+    public function __construct(ExceptionListener $innerListener, HybridRequestMatcher $hybridRequestMatcher, ExceptionConfigurator $exceptionConfigurator)
+    {
+        $this->innerListener = $innerListener;
+        $this->hybridRequestMatcher = $hybridRequestMatcher;
+        $this->configurator = $exceptionConfigurator;
+    }
+
+    /**
+     * Configures the exception as rendered by the HttpKernel listener into the app so that it gets rendered.
+     *
+     * @param \Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent $event
+     */
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        $this->innerListener->onKernelException($event);
+
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        if (!$this->hybridRequestMatcher->matches($event->getRequest())) {
+            return;
+        }
+
+        $this->configurator->configureException($event->getException(), $event->getResponse());
+    }
+}

--- a/src/lib/EventSubscriber/AppRendererSubscriber.php
+++ b/src/lib/EventSubscriber/AppRendererSubscriber.php
@@ -3,6 +3,7 @@
 namespace EzSystems\HybridPlatformUi\EventSubscriber;
 
 use EzSystems\HybridPlatformUi\App\AppResponseRenderer;
+use EzSystems\HybridPlatformUi\App\ToolbarsConfigurator;
 use EzSystems\HybridPlatformUi\Components\App;
 use EzSystems\HybridPlatformUi\Http\HybridRequestMatcher;
 use EzSystems\HybridPlatformUi\Http\Response\NoRenderResponse;
@@ -27,14 +28,21 @@ class AppRendererSubscriber implements EventSubscriberInterface
      */
     private $appRenderer;
 
+    /**
+     * @var \EzSystems\HybridPlatformUi\App\ToolbarsConfigurator
+     */
+    private $toolbarsConfigurator;
+
     public function __construct(
         App $app,
         AppResponseRenderer $appRenderer,
-        HybridRequestMatcher $hybridRequestMatcher
+        HybridRequestMatcher $hybridRequestMatcher,
+        ToolbarsConfigurator $toolbarsConfigurator
     ) {
         $this->hybridRequestMatcher = $hybridRequestMatcher;
         $this->app = $app;
         $this->appRenderer = $appRenderer;
+        $this->toolbarsConfigurator = $toolbarsConfigurator;
     }
 
     public static function getSubscribedEvents()
@@ -62,6 +70,7 @@ class AppRendererSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $this->toolbarsConfigurator->configureToolbars($this->app);
         $this->appRenderer->render($response, $this->app);
     }
 }

--- a/src/lib/EventSubscriber/AppRendererSubscriber.php
+++ b/src/lib/EventSubscriber/AppRendererSubscriber.php
@@ -8,7 +8,6 @@ use EzSystems\HybridPlatformUi\Http\HybridRequestMatcher;
 use EzSystems\HybridPlatformUi\Http\Response\NoRenderResponse;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class AppRendererSubscriber implements EventSubscriberInterface
@@ -40,12 +39,14 @@ class AppRendererSubscriber implements EventSubscriberInterface
 
     public static function getSubscribedEvents()
     {
-        return [KernelEvents::RESPONSE => ['renderApp', 5]];
+        return [
+            KernelEvents::RESPONSE => ['renderApp', 5],
+        ];
     }
 
     public function renderApp(FilterResponseEvent $event)
     {
-        if ($event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST) {
+        if (!$event->isMasterRequest()) {
             return;
         }
 

--- a/src/lib/EventSubscriber/PjaxSubscriber.php
+++ b/src/lib/EventSubscriber/PjaxSubscriber.php
@@ -67,7 +67,8 @@ class PjaxSubscriber implements EventSubscriberInterface
         if (
             $event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST ||
             !$this->adminRequestMatcher->matches($request) ||
-            !$this->isPjax($request, $response)
+            !$this->isPjax($request, $response) ||
+            $this->isError($response)
         ) {
             return;
         }
@@ -87,5 +88,10 @@ class PjaxSubscriber implements EventSubscriberInterface
     {
         return $this->pjaxRequestMatcher->matches($request)
             || $this->pjaxResponseMatcher->matches($response);
+    }
+
+    private function isError($response)
+    {
+        return $response->isClientError() || $response->isServerError();
     }
 }

--- a/src/lib/Http/Response/NotificationResponse.php
+++ b/src/lib/Http/Response/NotificationResponse.php
@@ -26,7 +26,7 @@ class NotificationResponse extends Response implements NoRenderResponse
             $notification->timeout,
             ($notification->copyable) ? ' copyable' : '',
             (trim($notification->details)) ? ' details="' . $notification->details . '"' : '',
-            $notification->message
+            $notification->content
         );
     }
 }

--- a/src/lib/NavigationHub/Link.php
+++ b/src/lib/NavigationHub/Link.php
@@ -19,7 +19,7 @@ abstract class Link
      */
     abstract public function getUrl();
 
-    public function __toString()
+    public function renderToString()
     {
         $disabled = '';
         $url = $this->getUrl();

--- a/src/lib/Notification/Notification.php
+++ b/src/lib/Notification/Notification.php
@@ -12,7 +12,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * Can be cast to a string for sending as a Response but most use cases will just access properties of it.
  *
  * @property-read string $type
- * @property-read string $message
+ * @property-read string $content
  * @property-read int $timeout
  * @property-read bool $copyable
  * @property-read string $details
@@ -39,7 +39,7 @@ class Notification extends ValueObject
      *
      * @var string
      */
-    protected $message;
+    protected $content;
 
     /**
      * Message timeout.

--- a/src/lib/Notification/NotificationPoolAwareTrait.php
+++ b/src/lib/Notification/NotificationPoolAwareTrait.php
@@ -55,7 +55,7 @@ trait NotificationPoolAwareTrait
         $notification = new Notification([
             'type' => Notification::TYPE_SUCCESS,
             /** @Ignore */
-            'message' => $this->translator->trans($message, $params, $domain),
+            'content' => $this->translator->trans($message, $params, $domain),
         ]);
 
         $this->notificationPool->add($notification);


### PR DESCRIPTION
> Status: ready for review
> [EZP-27476](https://jira.ez.no/browse/EZP-27476)

Adds exception handling to the `AppRendererSubscriber`. On exceptions, an `App\ExceptionConfigurator` will configure the newly added App's `exception` configuration property. Rendering of the `App` is modified to render _only_ the exception when there is an error notification.

A new `Notifications` component is added. It uses the `NotificationPool` to fetch notifications upon rendering. If an exception is set through the app, it renders that exception alone instead of regular notifications.

In all components, `__toString()` is replaced by `renderToString()`, since exceptions can't be handled with it.

To facilitate testing, a refactoring of toolbars configuration has been done. They are now configured through the `AppRendererSubscriber`, using a `ToolbarsConfigurator` service. The current implementation uses a hardcoded route comparison, and enables the `discovery` bar for `ez_urlalias`.

It also refactors the app rendering by removing the `AppResponseRenderer`. It had always felt odd, as the App has its own interface: it can be converted to a string or serialized to json, and it is all we need. Doing so avoids the leak of Symfony specific objects (`Request`, `Response`) to the library layer. The downside is that it makes the renderer a _bit_ more complex, as it uses three request matchers. But the responsibilities feel like they're in the right place.

### TODO
- [x] Specs (`Components\Notifications`)
- [x] Finalize full page rendering of exceptions (401, 403, 404)
- [x] Verify that the app exception rendering based on 1 error notification is sufficient and doesn't have unwanted side effects
- [x] Remove test commit
- [x] Screenshots
- [x] Use Notification objects once merged