### PR TITLE
EZP-27579: Move loading locations to ParameterSupplier so that it can be shared

### DIFF
--- a/spec/View/Content/Locations/LocationParameterSupplierSpec.php
+++ b/spec/View/Content/Locations/LocationParameterSupplierSpec.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace spec\EzSystems\HybridPlatformUi\View\Content\Locations;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use EzSystems\HybridPlatformUi\Repository\UiLocationService;
+use EzSystems\HybridPlatformUi\Repository\Values\Content\UiLocation;
+use EzSystems\HybridPlatformUi\View\Content\ParameterSupplier;
+use PhpSpec\ObjectBehavior;
+
+class LocationParameterSupplierSpec extends ObjectBehavior
+{
+    function let(UiLocationService $uiLocationService)
+    {
+        $this->beConstructedWith($uiLocationService);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ParameterSupplier::class);
+    }
+
+    function it_should_supply_us_with_a_list_of_locations(
+        UiLocationService $uiLocationService,
+        ContentView $contentView,
+        UiLocation $uiLocation
+    ) {
+        $contentInfo = new ContentInfo();
+        $versionInfo = new VersionInfo(['contentInfo' => $contentInfo]);
+        $content = new Content(['versionInfo' => $versionInfo]);
+        $contentView->getContent()->willReturn($content);
+
+        $uiLocationService->loadLocations($contentInfo)->willReturn([$uiLocation]);
+
+        $contentView->addParameters(['locations' => [$uiLocation]])->shouldBeCalled();
+
+        $this->supply($contentView);
+    }
+}

--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -15,6 +15,7 @@ use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
 use EzSystems\HybridPlatformUi\Form\UiFormFactory;
 use EzSystems\HybridPlatformUi\Repository\UiLocationService;
+use EzSystems\HybridPlatformUi\View\Content\Locations\LocationParameterSupplier;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
@@ -43,17 +44,20 @@ class LocationController extends TabController
     }
 
     public function contentViewTabAction(
-        ContentView $view
+        ContentView $view,
+        LocationParameterSupplier $locationParameterSupplier
     ) {
         $versionInfo = $view->getContent()->getVersionInfo();
         $contentInfo = $versionInfo->getContentInfo();
 
         if ($contentInfo->published) {
-            $locations = $this->uiLocationService->loadLocations($contentInfo);
-            $actionsForm = $this->formFactory->createLocationsActionForm($locations);
+            $locationParameterSupplier->supply($view);
+
+            $actionsForm = $this->formFactory->createLocationsActionForm(
+                $view->hasParameter('locations') ? $view->getParameter('locations') : []
+            );
 
             $view->addParameters([
-                'locations' => $locations,
                 'actionsForm' => $actionsForm->createView(),
             ]);
         }

--- a/src/lib/View/Content/Locations/LocationParameterSupplier.php
+++ b/src/lib/View/Content/Locations/LocationParameterSupplier.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\HybridPlatformUi\View\Content\Locations;
+
+use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use EzSystems\HybridPlatformUi\Repository\UiLocationService;
+use EzSystems\HybridPlatformUi\View\Content\ParameterSupplier;
+
+/**
+ * Adds parameters needed to display locations.
+ */
+class LocationParameterSupplier implements ParameterSupplier
+{
+    /**
+     * @var UiLocationService
+     */
+    private $uiLocationService;
+
+    public function __construct(UiLocationService $uiLocationService)
+    {
+        $this->uiLocationService = $uiLocationService;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supply(ContentView $contentView)
+    {
+        $contentView->addParameters([
+            'locations' => $this->uiLocationService->loadLocations($contentView->getContent()->contentInfo),
+        ]);
+    }
+}


### PR DESCRIPTION
As part of https://jira.ez.no/browse/EZP-27579 we will need to load the locations to display the breadcrumbs.
Therefore refactoring loading locations to use a `ParameterSupplier` so that it can be used elsewhere.