### PR TITLE
EZP-27572: Enable buttons only when something is selected

### DIFF
--- a/src/bundle/Resources/views/content/tabs/locations.html.twig
+++ b/src/bundle/Resources/views/content/tabs/locations.html.twig
@@ -15,64 +15,66 @@
     })
 }}
 
-<div class="ez-list-toolbar">
-    <h2 class="ez-list-toolbar-label">{{ 'locationview.locations.content.locations'|trans()|desc('Content locations') }}</h2>
-    <div class="ez-list-toolbar-tools">
-        {{ form_widget(actionsForm.parentLocationIds) }}
-        {{
-            form_widget(actionsForm.add, {
-                'label': 'locationview.locations.add.location'|trans()|desc('Add Location'),
-                'attr': {
-                    'class': 'ez-button ez-button-secondary ez-js-run-universal-discovery',
-                    'data-ud-title': 'select.location.to.create.new.location'|trans()|desc('Select the location where you want to create new location'),
-                    'data-ud-multiple': true,
-                    'data-ud-container': true,
-                    'data-ud-confirm-fill': '#' ~ actionsForm.parentLocationIds.vars.id,
-                    'data-ud-confirm-fill-with': 'location.id',
-                }
-            })
-        }}
-        <button type="button" value="#{{ dialogId }}" class="ez-button ez-button-negative ez-js-open-modal">
-            {{ 'locationview.locations.delete.locations'|trans()|desc('Delete selected locations') }}
-        </button>
+<ez-selection-activate-element>
+    <div class="ez-list-toolbar">
+        <h2 class="ez-list-toolbar-label">{{ 'locationview.locations.content.locations'|trans()|desc('Content locations') }}</h2>
+        <div class="ez-list-toolbar-tools">
+            {{ form_widget(actionsForm.parentLocationIds) }}
+            {{
+                form_widget(actionsForm.add, {
+                    'label': 'locationview.locations.add.location'|trans()|desc('Add Location'),
+                    'attr': {
+                        'class': 'ez-button ez-button-secondary ez-js-run-universal-discovery',
+                        'data-ud-title': 'select.location.to.create.new.location'|trans()|desc('Select the location where you want to create new location'),
+                        'data-ud-multiple': true,
+                        'data-ud-container': true,
+                        'data-ud-confirm-fill': '#' ~ actionsForm.parentLocationIds.vars.id,
+                        'data-ud-confirm-fill-with': 'location.id',
+                    }
+                })
+            }}
+            <button type="button" value="#{{ dialogId }}" class="ez-button ez-button-negative ez-js-open-modal ez-js-activable-element" disabled>
+                {{ 'locationview.locations.delete.locations'|trans()|desc('Delete selected locations') }}
+            </button>
+        </div>
     </div>
-</div>
 
-<table class="ez-table-data">
-    <thead>
-        <tr>
-            <th></th>
-            <th>{{ 'locationview.locations.path'|trans()|desc('Path') }}</th>
-            <th>{{ 'locationview.locations.subitems'|trans()|desc('Sub-items') }}</th>
-            <th colspan="2">{{ 'locationview.locations.visibility'|trans()|desc('Visibility') }}</th>
-            <th>{{ 'locationview.locations.main'|trans()|desc('Main') }}</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% if locations is defined %}
-        {% for location in locations %}
-        <tr>
-            <td>{{ form_widget(actionsForm.removeLocations[location.id], {'attr': {'disabled': not location.canDelete}}) }}</td>
-            <td>{{ include('@EzSystemsHybridPlatformUi/fields/location/path.html.twig', {'locations': location.pathLocations}) }}</td>
-            <td>{{ location.childCount }}</td>
-            <td>
-                {% if location.hidden %}
-                    {{ 'locationview.locations.hidden'|trans()|desc('Hidden') }}
-                {% else %}
-                    {% if location.invisible %}
-                        {{ 'locationview.locations.hidden.by.superior'|trans()|desc('Hidden by superior') }}
+    <table class="ez-table-data">
+        <thead>
+            <tr>
+                <th></th>
+                <th>{{ 'locationview.locations.path'|trans()|desc('Path') }}</th>
+                <th>{{ 'locationview.locations.subitems'|trans()|desc('Sub-items') }}</th>
+                <th colspan="2">{{ 'locationview.locations.visibility'|trans()|desc('Visibility') }}</th>
+                <th>{{ 'locationview.locations.main'|trans()|desc('Main') }}</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% if locations is defined %}
+            {% for location in locations %}
+            <tr>
+                <td>{{ form_widget(actionsForm.removeLocations[location.id], {'attr': {'disabled': not location.canDelete}}) }}</td>
+                <td>{{ include('@EzSystemsHybridPlatformUi/fields/location/path.html.twig', {'locations': location.pathLocations}) }}</td>
+                <td>{{ location.childCount }}</td>
+                <td>
+                    {% if location.hidden %}
+                        {{ 'locationview.locations.hidden'|trans()|desc('Hidden') }}
                     {% else %}
-                        {{ 'locationview.locations.visible'|trans()|desc('Visible') }}
+                        {% if location.invisible %}
+                            {{ 'locationview.locations.hidden.by.superior'|trans()|desc('Hidden by superior') }}
+                        {% else %}
+                            {{ 'locationview.locations.visible'|trans()|desc('Visible') }}
+                        {% endif %}
                     {% endif %}
-                {% endif %}
-            </td>
-            <td></td>
-            <td></td>
-        </tr>
-        {% endfor %}
-    {% endif %}
-    </tbody>
-</table>
+                </td>
+                <td></td>
+                <td></td>
+            </tr>
+            {% endfor %}
+        {% endif %}
+        </tbody>
+    </table>
+</ez-selection-activate-element>
 
 {{ form_end(actionsForm) }}
 

--- a/src/bundle/Resources/views/content/tabs/translations.html.twig
+++ b/src/bundle/Resources/views/content/tabs/translations.html.twig
@@ -1,30 +1,36 @@
 {% trans_default_domain "locationview" %}
 {{ form_start(actionsForm, {'action': path('ez_hybrid_platform_ui_translation_actions', {'contentId': content.id, 'redirectLocationId': location.id})}) }}
 
-<div class="ez-list-toolbar">
-    <h2 class="ez-list-toolbar-label">{{ 'locationview.translations.title'|trans|desc('Translation manager') }}</h2>
-    <div class="container-buttons">
-        {{ form_widget(actionsForm.delete, {'label': 'locationview.translations.delete.translations'|trans()|desc('Delete selected translations'), 'attr': {'class': 'ez-button ez-button-negative'}}) }}
+<ez-selection-activate-element>
+    <div class="ez-list-toolbar">
+        <h2 class="ez-list-toolbar-label">{{ 'locationview.translations.title'|trans|desc('Translation manager') }}</h2>
+        <div class="container-buttons">
+            {{
+                form_widget(actionsForm.delete, {
+                    'label': 'locationview.translations.delete.translations'|trans()|desc('Delete selected translations'),
+                    'attr': {'class': 'ez-button ez-button-negative ez-js-activable-element', 'disabled': true}
+                })
+            }}
+        </div>
     </div>
-</div>
 
-<table class="ez-table-data">
-    <thead>
-        <tr>
-            <th></th>
-            <th>{{ 'locationview.translations.languagename'|trans|desc('Language name') }}</th>
-            <th>{{ 'locationview.translations.languagecode'|trans|desc('Language code') }}</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for translation in translations %}
-        <tr>
-            <td>{{ form_widget(actionsForm.removeTranslations[translation.languageCode], {'attr': {'disabled': not translation.canDelete}}) }}</td>
-            <td>{{ translation.name }}</td>
-            <td>{{ translation.languageCode }}</td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
-
+    <table class="ez-table-data">
+        <thead>
+            <tr>
+                <th></th>
+                <th>{{ 'locationview.translations.languagename'|trans|desc('Language name') }}</th>
+                <th>{{ 'locationview.translations.languagecode'|trans|desc('Language code') }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for translation in translations %}
+            <tr>
+                <td>{{ form_widget(actionsForm.removeTranslations[translation.languageCode], {'attr': {'disabled': not translation.canDelete}}) }}</td>
+                <td>{{ translation.name }}</td>
+                <td>{{ translation.languageCode }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</ez-selection-activate-element>
 {{ form_end(actionsForm) }}

--- a/src/bundle/Resources/views/content/tabs/translations.html.twig
+++ b/src/bundle/Resources/views/content/tabs/translations.html.twig
@@ -1,16 +1,25 @@
 {% trans_default_domain "locationview" %}
 {{ form_start(actionsForm, {'action': path('ez_hybrid_platform_ui_translation_actions', {'contentId': content.id, 'redirectLocationId': location.id})}) }}
 
+{% set dialogId = 'confirm-translations-removal-' ~ location.id %}
+{{
+    include('@EzSystemsHybridPlatformUi/components/confirm_delete_dialog.html.twig', {
+        'dialogId': dialogId,
+        'message': 'confirm.remove.translations'|trans()|desc('Are you sure you want to remove selected translations?'),
+        'confirmButton': actionsForm.delete,
+    })
+}}
+
 <ez-selection-activate-element>
     <div class="ez-list-toolbar">
         <h2 class="ez-list-toolbar-label">{{ 'locationview.translations.title'|trans|desc('Translation manager') }}</h2>
-        <div class="container-buttons">
-            {{
-                form_widget(actionsForm.delete, {
-                    'label': 'locationview.translations.delete.translations'|trans()|desc('Delete selected translations'),
-                    'attr': {'class': 'ez-button ez-button-negative ez-js-activable-element', 'disabled': true}
-                })
-            }}
+        <div class="ez-list-toolbar-tools">
+            <button type="button"
+                value="#{{ dialogId }}"
+                disabled
+                class="ez-button ez-button-negative ez-js-open-modal ez-js-activable-element">
+                {{ 'locationview.translations.delete.translations'|trans()|desc('Delete selected translations') }}
+            </button>
         </div>
     </div>
 

--- a/src/bundle/Resources/views/content/tabs/versions.html.twig
+++ b/src/bundle/Resources/views/content/tabs/versions.html.twig
@@ -13,26 +13,28 @@
         })
     }}
 
-    <div class="ez-list-toolbar">
-        <h2 class="ez-list-toolbar-label">{{ 'locationview.versions.draft.under.edit'|trans()|desc('Draft under edit') }}</h2>
-        <div class="ez-list-toolbar-tools">
-            <button type="button" value="#{{ draftDialogId }}" class="ez-button ez-button-negative ez-js-open-modal"
-                {% if draftVersions is not defined %}disabled{% endif %}>
-                {{ 'locationview.versions.delete'|trans()|desc('Delete') }}
-            </button>
+    <ez-selection-activate-element>
+        <div class="ez-list-toolbar">
+            <h2 class="ez-list-toolbar-label">{{ 'locationview.versions.draft.under.edit'|trans()|desc('Draft under edit') }}</h2>
+            <div class="ez-list-toolbar-tools">
+                <button type="button"
+                    value="#{{ draftDialogId }}"
+                    disabled
+                    class="ez-button ez-button-negative ez-js-open-modal ez-js-activable-element">
+                    {{ 'locationview.versions.delete'|trans()|desc('Delete') }}
+                </button>
+            </div>
         </div>
-    </div>
 
-    {% if draftVersions is defined %}
-        {{ include('@EzSystemsHybridPlatformUi/content/tabs/versions/table.html.twig', {'versions': draftVersions, 'form': draftActionsForm, 'isDraft': true}) }}
-    {% else %}
-        <p class="ez-relations-box-list-no-content">
-            {{ 'locationview.versions.no.permission'|trans()|desc("You don't have access to view the content item's versions") }}
-        </p>
-    {% endif %}
-
+        {% if draftVersions is defined %}
+            {{ include('@EzSystemsHybridPlatformUi/content/tabs/versions/table.html.twig', {'versions': draftVersions, 'form': draftActionsForm, 'isDraft': true}) }}
+        {% else %}
+            <p class="ez-relations-box-list-no-content">
+                {{ 'locationview.versions.no.permission'|trans()|desc("You don't have access to view the content item's versions") }}
+            </p>
+        {% endif %}
+    </ez-selection-activate-element>
     {{ form_end(draftActionsForm) }}
-
 {% endif %}
 
 {% if publishedVersions is not defined or publishedVersions %}
@@ -64,30 +66,35 @@
         })
     }}
 
-    <div class="ez-list-toolbar">
-        <h2 class="ez-list-toolbar-label">{{ 'locationview.versions.archived.versions'|trans()|desc('Archived versions') }}</h2>
-        <div class="ez-list-toolbar-tools">
-            {{
-                form_widget(archivedActionsForm.new_draft, {
-                    'label': 'locationview.versions.new.draft.selected.version'|trans()|desc('New draft based on selected version'),
-                    'attr': {'class': 'ez-button ez-button-secondary', 'disabled': archivedVersions is not defined}
-                })
-            }}
-            <button type="button" value="#{{ archivedDialogId }}" class="ez-button ez-button-negative ez-js-open-modal"
-                {% if archivedVersions is not defined %}disabled{% endif %}>
-                {{ 'locationview.versions.delete'|trans()|desc('Delete') }}
-            </button>
+    <ez-selection-activate-element>
+        <div class="ez-list-toolbar">
+            <h2 class="ez-list-toolbar-label">{{ 'locationview.versions.archived.versions'|trans()|desc('Archived versions') }}</h2>
+            <div class="ez-list-toolbar-tools">
+                {{
+                    form_widget(archivedActionsForm.new_draft, {
+                        'label': 'locationview.versions.new.draft.selected.version'|trans()|desc('New draft based on selected version'),
+                        'attr': {
+                            'class': 'ez-button ez-button-secondary ez-js-activable-element ez-js-activable-element-single-selection',
+                            'disabled': true
+                        }
+                    })
+                }}
+                <button type="button"
+                    value="#{{ archivedDialogId }}"
+                    disabled
+                    class="ez-button ez-button-negative ez-js-open-modal ez-js-activable-element">
+                    {{ 'locationview.versions.delete'|trans()|desc('Delete') }}
+                </button>
+            </div>
         </div>
-    </div>
 
-    {% if archivedVersions is defined %}
-        {{ include('@EzSystemsHybridPlatformUi/content/tabs/versions/table.html.twig', {'versions': archivedVersions, 'form': archivedActionsForm}) }}
-    {% else %}
-        <p class="ez-relations-box-list-no-content">
-            {{ 'locationview.versions.no.permission'|trans()|desc("You don't have access to view the content item's versions") }}
-        </p>
-    {% endif %}
-
+        {% if archivedVersions is defined %}
+            {{ include('@EzSystemsHybridPlatformUi/content/tabs/versions/table.html.twig', {'versions': archivedVersions, 'form': archivedActionsForm}) }}
+        {% else %}
+            <p class="ez-relations-box-list-no-content">
+                {{ 'locationview.versions.no.permission'|trans()|desc("You don't have access to view the content item's versions") }}
+            </p>
+        {% endif %}
+    </ez-selection-activate-element>
     {{ form_end(archivedActionsForm) }}
-
 {% endif %}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27572
Requires: https://github.com/ezsystems/hybrid-platform-ui-core-components/pull/30

# Description

Use the `<ez-selection-activate-element>` component in Locations, Versions and Translations tabs to enable buttons only when something is selected.

screencast: https://youtu.be/whZ4s7zKQqs

# Test

manual tests