### PR TITLE
[spike] UDW integration to select locations

### DIFF
--- a/src/bundle/Controller/LocationController.php
+++ b/src/bundle/Controller/LocationController.php
@@ -89,7 +89,7 @@ class LocationController extends TabController
         Location $location,
         Request $request
     ) {
-        $swapLocationsForm = $this->formFactory->createLocationsContentSwapForm();
+        $swapLocationsForm = $this->formFactory->createLocationsContentSwapForm($location);
         $swapLocationsForm->handleRequest($request);
 
         if ($swapLocationsForm->isValid()) {

--- a/src/bundle/Form/Locations/Actions.php
+++ b/src/bundle/Form/Locations/Actions.php
@@ -9,7 +9,6 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class Actions extends AbstractType
@@ -19,7 +18,7 @@ class Actions extends AbstractType
         $builder
             ->add('delete', SubmitType::class)
             ->add('add', SubmitType::class)
-            ->add('parentLocationId', TextType::class, ['required' => false])
+            ->add('parentLocationId', LocationSelectionType::class, ['widget' => 'udw'])
             ->add(
                 'removeLocations',
                 CollectionType::class,

--- a/src/bundle/Form/Locations/LocationSelectionType.php
+++ b/src/bundle/Form/Locations/LocationSelectionType.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\HybridPlatformUiBundle\Form\Locations;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class LocationSelectionType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'type' => 'single',
+            'starting_location_id' => 2,
+            'include_content_types' => [],
+            'exclude_content_types' => [],
+            'widget' => 'text',
+        ]);
+        $resolver->setAllowedValues('type', ['single', 'multiple']);
+        $resolver->setAllowedValues('widget', ['text', 'udw']);
+        $resolver->setAllowedTypes('starting_location_id', 'int');
+    }
+
+    public function getParent()
+    {
+        return NumberType::class;
+    }
+
+    public function finishView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['widget'] = $options['widget'];
+        $view->vars['starting_location_id'] = $options['starting_location_id'];
+    }
+}

--- a/src/bundle/Form/Locations/LocationSwap.php
+++ b/src/bundle/Form/Locations/LocationSwap.php
@@ -6,7 +6,6 @@
 namespace EzSystems\HybridPlatformUiBundle\Form\Locations;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -17,7 +16,16 @@ class LocationSwap extends AbstractType
         parent::buildForm($builder, $options);
 
         $builder
-            ->add('new_location_id', NumberType::class)
+            /**
+             * Could/should be a LocationSelectionType.
+             * It would/could have a UniversalDiscoveryWidget appearance.
+             * But in any case, it has options:
+             * - single/multiple
+             * - selectable types ?
+             * - start location ?
+             * Or this could be done from the template, with reusable elements.
+             */
+            ->add('new_location_id', LocationSelectionType::class, ['type' => 'single', 'widget' => 'udw'])
             ->add('swap', SubmitType::class);
     }
 }

--- a/src/bundle/Resources/views/form/location_selection.html.twig
+++ b/src/bundle/Resources/views/form/location_selection.html.twig
@@ -1,0 +1,17 @@
+{% block location_selection_widget %}
+    {% if widget == "text" %}
+        {{ block('number_widget') }}
+    {% endif %}
+
+    {% if widget == "udw" %}
+        {{ block('hidden_widget') }}
+        <script>
+            document.addEventListener('ez:locationSelected', (e) => {{ '{' }}
+                document.querySelector('#{{ id }}').value = e.detail.locationId;
+            {{ '}' }});
+        </script>
+        <ez-select-location selected-location-id="{{ starting_location_id }}">
+            Select location
+        </ez-select-location>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
> Requires https://github.com/ezsystems/hybrid-platform-ui-core-components/pull/34

Adds a `LocationSelectionType` FormType, that allows to select a location. The `widget` option allows to choose between `text` and `udw`. The first shows a text input for a location id, while the second shows an `<ez-select-location>` item that opens the UDW. The selected location's id is set to the hidden form field by hooking into the `ez:locationSelected` event.

### Known bugs
It won't work from the full location view, only from the tab itself: http://localhost:8000/admin/view/content/{contentId}/locations_tab/1/{locationId}. The listener doesn't set the value in full view.