### PR TITLE
EZP-27355: Mapped view title to app title

### DIFF
--- a/src/lib/Components/App.php
+++ b/src/lib/Components/App.php
@@ -98,6 +98,7 @@ class App implements Component
                     'toolbars' => $this->toolbars,
                     'mainContent' => $this->mainContent,
                     'appTagName' => self::TAG_NAME,
+                    'title' => $this->title,
                 ]
             );
         }

--- a/src/lib/View/AppConfigCoreViewMainContentMapper.php
+++ b/src/lib/View/AppConfigCoreViewMainContentMapper.php
@@ -5,6 +5,7 @@
  */
 namespace EzSystems\HybridPlatformUi\View;
 
+use eZ\Publish\Core\MVC\Symfony\View\ContentView;
 use eZ\Publish\Core\MVC\Symfony\View\View;
 use EzSystems\HybridPlatformUi\Components\App;
 use EzSystems\HybridPlatformUi\Components\MainContent;
@@ -38,6 +39,18 @@ class AppConfigCoreViewMainContentMapper implements CoreViewMainContentMapper
                 'template' => $view->getTemplateIdentifier(),
                 'parameters' => $view->getParameters(),
             ],
+            'title' => $this->getTitle($view),
         ]);
+    }
+
+    private function getTitle(View $view)
+    {
+        if ($view instanceof ContentView) {
+            return $view->getContent()->getName();
+        } else {
+            if ($view->hasParameter('title')) {
+                return $view->getParameter('title');
+            }
+        }
     }
 }


### PR DESCRIPTION
If a view is a `ContentView`, it uses the Content's name.
If it is any view, it uses the 'title' parameter if it is set.

### TODO
- [ ] Consider refactoring extracting the title.
- [ ] Update specs, refactoring or not
- [ ] See if we want the content's name or more (path ?)