### PR TITLE
Add priority to navigation tags so we are able to set navigation display order

### DIFF
--- a/docs/howto/add_navigation_hub_items.md
+++ b/docs/howto/add_navigation_hub_items.md
@@ -114,3 +114,18 @@ A setter method `setRoutePrefix` can be used to define a route prefix used to ma
 If given, a Request's route with the same prefix will match (example: `admin_sectionedit` matches the
 `admin_section` prefix).
 
+## Position
+Order of both, links and zones, can be set. It's implemented in a *Symfony way* as a `priority` parameter of service definition tag:
+
+```yaml
+services:
+    ezsystems.platformui.navigationhub.link.admin.dashboard:
+        # ...
+        tags:
+            - name: ezplatform.ui.link
+              priority: 100
+```
+
+Lower `priority` values will make links appear first, those with the same `priority` value will appear in an order of definition, higher values obviously later.
+Good practice is to make default values multiplier of `10` or `100`, so end-user will be able to inject own links (or zones) between default ones (ie. by setting `priority` to `50`).
+Default value of omitted `priority` parameter is `0`. Negative values are accepted as well.

--- a/src/bundle/DependencyInjection/Compiler/NavigationHubPass.php
+++ b/src/bundle/DependencyInjection/Compiler/NavigationHubPass.php
@@ -34,7 +34,7 @@ class NavigationHubPass implements CompilerPassInterface
         }
 
         $sorted = [];
-        krsort($unsorted);
+        ksort($unsorted);
         foreach ($unsorted as $items) {
             $sorted = array_merge($sorted, $items);
         }

--- a/src/bundle/DependencyInjection/Compiler/NavigationHubPass.php
+++ b/src/bundle/DependencyInjection/Compiler/NavigationHubPass.php
@@ -24,14 +24,23 @@ class NavigationHubPass implements CompilerPassInterface
 
     private function processNavigationHubTag(ContainerBuilder $container, $tag, $index)
     {
-        $items = [];
+        $unsorted = [];
         $services = $container->findTaggedServiceIds($tag);
-        foreach (array_keys($services) as $serviceId) {
-            $items[] = new Reference($serviceId);
+        foreach ($services as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                $priority = isset($tag['priority']) ? $tag['priority'] : 0;
+            }
+            $unsorted[$priority][] = new Reference($serviceId);
+        }
+
+        $sorted = [];
+        krsort($unsorted);
+        foreach ($unsorted as $items) {
+            $sorted = array_merge($sorted, $items);
         }
 
         $container
             ->findDefinition(NavigationHub::class)
-            ->replaceArgument($index, $items);
+            ->replaceArgument($index, $sorted);
     }
 }

--- a/src/bundle/Resources/config/navigationhub.yml
+++ b/src/bundle/Resources/config/navigationhub.yml
@@ -15,7 +15,8 @@ services:
             - "Content"
             - "content"
         tags:
-            - {name: ezplatform.ui.zone}
+            - name: ezplatform.ui.zone
+              priority: 100
 
     ezsystems.platformui.navigationhub.zones.page:
         class: "%ezsystems.platformui.navigationhub.zone.class%"
@@ -23,7 +24,8 @@ services:
             - "Page"
             - "page"
         tags:
-            - {name: ezplatform.ui.zone}
+            - name: ezplatform.ui.zone
+              priority: 200
 
     ezsystems.platformui.navigationhub.zones.performances:
         class: "%ezsystems.platformui.navigationhub.zone.class%"
@@ -31,7 +33,8 @@ services:
             - "Performances"
             - "performances"
         tags:
-            - {name: ezplatform.ui.zone}
+            - name: ezplatform.ui.zone
+              priority: 300
 
     ezsystems.platformui.navigationhub.zones.admin:
         class: "%ezsystems.platformui.navigationhub.zone.class%"
@@ -39,7 +42,8 @@ services:
             - "Admin Panel"
             - "admin"
         tags:
-            - {name: ezplatform.ui.zone}
+            - name: ezplatform.ui.zone
+              priority: 400
 
     ezsystems.platformui.navigationhub.link.contentstructure:
         class: "%ezsystems.platformui.navigationhub.link.subtree.class%"
@@ -49,7 +53,8 @@ services:
             - "content"
             - {locationId: 2}
         tags:
-            - {name: ezplatform.ui.link}
+            - name: ezplatform.ui.link
+              priority: 100
 
     ezsystems.platformui.navigationhub.link.medialibrary:
         class: "%ezsystems.platformui.navigationhub.link.subtree.class%"
@@ -59,7 +64,8 @@ services:
             - "content"
             - {locationId: 43}
         tags:
-            - {name: ezplatform.ui.link}
+            - name: ezplatform.ui.link
+              priority: 200
 
     ezsystems.platformui.navigationhub.link.admin.dashboard:
         class: "%ezsystems.platformui.navigationhub.link.route.class%"
@@ -69,7 +75,8 @@ services:
             - "Dashboard"
             - "admin"
         tags:
-            - {name: ezplatform.ui.link}
+            - name: ezplatform.ui.link
+              priority: 100
 
     ezsystems.platformui.navigationhub.link.admin.section:
         class: "%ezsystems.platformui.navigationhub.link.route.class%"
@@ -81,7 +88,8 @@ services:
         calls:
             - [setRoutePrefix, ["admin_section"]]
         tags:
-            - {name: ezplatform.ui.link}
+            - name: ezplatform.ui.link
+              priority: 200
 
     ezsystems.platformui.navigationhub.link.admin.languages:
         class: "%ezsystems.platformui.navigationhub.link.route.class%"
@@ -93,7 +101,8 @@ services:
         calls:
             - [setRoutePrefix, ["admin_language"]]
         tags:
-            - {name: ezplatform.ui.link}
+            - name: ezplatform.ui.link
+              priority: 300
 
     ezsystems.platformui.navigationhub.link.admin.content_types:
         class: "%ezsystems.platformui.navigationhub.link.route.class%"
@@ -105,7 +114,8 @@ services:
         calls:
             - [setRoutePrefix, ["admin_contenttype"]]
         tags:
-            - {name: ezplatform.ui.link}
+            - name: ezplatform.ui.link
+              priority: 400
 
     ezsystems.platformui.navigationhub.link.admin.roles:
         class: "%ezsystems.platformui.navigationhub.link.route.class%"
@@ -117,7 +127,8 @@ services:
         calls:
             - [setRoutePrefix, ["admin_role"]]
         tags:
-            - {name: ezplatform.ui.link}
+            - name: ezplatform.ui.link
+              priority: 500
 
     ezsystems.platformui.navigationhub.link.admin.system_info:
         class: "%ezsystems.platformui.navigationhub.link.route.class%"
@@ -127,4 +138,5 @@ services:
             - "System info"
             - "admin"
         tags:
-            - {name: ezplatform.ui.link}
+            - name: ezplatform.ui.link
+              priority: 600


### PR DESCRIPTION
Right now `NavigationHub` links (and zones) are in order of bundle loading, and because of most of our bundles use `PrependInterface` it's even more difficult to position new navigation options as we like.

This implementation adds `priority` (lower first) handling to `ezplatform.ui.link` and `ezplatform.ui.zone` compiler pass.