### PR TITLE
Add canary build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: php
 php:
     - 7.0
     - 7.1
+    - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 # test only master (+ Pull requests)
 branches:


### PR DESCRIPTION
It won't break the build but will allow to see if there's any
incompatibilities with PHP 7.2