### PR TITLE
EZP-27696: Hybrid Platform UI Dashboard blocks

### DIFF
--- a/src/bundle/Controller/DashboardController.php
+++ b/src/bundle/Controller/DashboardController.php
@@ -9,14 +9,38 @@
 namespace EzSystems\HybridPlatformUiBundle\Controller;
 
 use EzSystems\HybridPlatformUi\Components\MainContent;
+use EzSystems\HybridPlatformUi\Dashboard\Dashboard;
 use EzSystems\PlatformUIBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class DashboardController extends Controller
 {
+    protected $dashboard;
+
+    public function __construct(Dashboard $dashboard)
+    {
+        $this->dashboard = $dashboard;
+    }
+
     public function viewDashboardAction(MainContent $mainContent)
     {
         $mainContent->setTemplate('EzSystemsHybridPlatformUiBundle::dashboard.html.twig');
+        $mainContent->setParameters(['dashboard' => $this->dashboard]);
 
         return $mainContent;
+    }
+
+    public function viewTabAction(Request $request, $sectionIdentifier, $tabIdentifier)
+    {
+        $content = $this->dashboard
+            ->getSection($sectionIdentifier)
+            ->getTab($tabIdentifier);
+
+        return new Response(
+            $content->render(
+                $request->get('page', 1)
+            )
+        );
     }
 }

--- a/src/bundle/DependencyInjection/Compiler/DashboardPass.php
+++ b/src/bundle/DependencyInjection/Compiler/DashboardPass.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace EzSystems\HybridPlatformUiBundle\DependencyInjection\Compiler;
+
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use EzSystems\HybridPlatformUi\Dashboard\Dashboard;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class DashboardPass implements CompilerPassInterface
+{
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     * @param ContainerBuilder $container
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(Dashboard::class)) {
+            return;
+        }
+
+        $tagServices = $this->processTabs(
+            $container,
+            $container->findTaggedServiceIds('ezplatform.ui.dashboard.tab')
+        );
+
+        $sectionServices = $this->processSections(
+            $container,
+            $container->findTaggedServiceIds('ezplatform.ui.dashboard.section'),
+            $tagServices
+        );
+
+        $dashboardDefinition = $container->findDefinition(Dashboard::class);
+        $dashboardDefinition
+            ->addMethodCall('setSections', [$sectionServices]);
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array $tabs
+     *
+     * @return array
+     *
+     * @throws InvalidArgumentException
+     */
+    private function processTabs(ContainerBuilder $container, array $tabs): array
+    {
+        $tabServices = [];
+
+        foreach ($tabs as $refId => $tags) {
+            foreach ($tags as $tag) {
+                if (!isset($tag['section'])) {
+                    throw new InvalidArgumentException('section', "Tag 'ezplatform.ui.dashboard.tab' must have section information (refId: ${refId})");
+                }
+                if (!isset($tag['identifier'])) {
+                    throw new InvalidArgumentException('identifier', "Tag 'ezplatform.ui.dashboard.tab' must have identifier (refId: ${refId})");
+                }
+                $order = isset($tag['order']) ? $tag['order'] : 0;
+                $tabServices[$tag['section']][$order][$tag['identifier']] = new Reference($refId);
+            }
+        }
+
+        return $tabServices;
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array $sections
+     * @param array $tabServices
+     *
+     * @return array
+     *
+     * @throws InvalidArgumentException
+     */
+    private function processSections(ContainerBuilder $container, array $sections, array $tabServices): array
+    {
+        $sectionServices = [];
+        foreach ($sections as $refId => $tags) {
+            foreach ($tags as $tag) {
+                if (!isset($tag['identifier'])) {
+                    throw new InvalidArgumentException('identifier', "Tag 'ezplatform.ui.dashboard.section' must have identifier (refId: ${refId})");
+                }
+                $order = isset($tag['order']) ? $tag['order'] : 0;
+
+                $unsorted = $tabServices[$tag['identifier']];
+                ksort($unsorted);
+
+                $sortedServices = [];
+                foreach ($unsorted as $items) {
+                    $sortedServices = array_merge($sortedServices, $items);
+                }
+
+                $sectionDefinition = $container->findDefinition($refId);
+                $sectionDefinition
+                    ->addMethodCall('setTabs', [$sortedServices]);
+
+                $sectionServices[$order][$tag['identifier']] = new Reference($refId);
+            }
+        }
+        ksort($sectionServices);
+
+        $sortedServices = [];
+        foreach ($sectionServices as $items) {
+            $sortedServices = array_merge($sortedServices, $items);
+        }
+
+        return $sortedServices;
+    }
+}

--- a/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
+++ b/src/bundle/DependencyInjection/EzSystemsHybridPlatformUiExtension.php
@@ -30,6 +30,7 @@ class EzSystemsHybridPlatformUiExtension extends Extension implements PrependExt
         $loader->load('components.yml');
         $loader->load('pjax.yml');
         $loader->load('repository.yml');
+        $loader->load('dashboard.yml');
     }
 
     public function prepend(ContainerBuilder $container)
@@ -37,6 +38,7 @@ class EzSystemsHybridPlatformUiExtension extends Extension implements PrependExt
         $this->prependViewsConfiguration($container);
         $this->prependFosJsRoutingConfiguration($container);
         $this->prependLayoutConfiguration($container);
+        $this->prependRouterConfiguration($container);
     }
 
     private function prependViewsConfiguration(ContainerBuilder $container)
@@ -60,5 +62,20 @@ class EzSystemsHybridPlatformUiExtension extends Extension implements PrependExt
         $config = Yaml::parse(file_get_contents($configFile));
         $container->prependExtensionConfig('ezpublish', $config);
         $container->addResource(new FileResource($configFile));
+    }
+
+    private function prependRouterConfiguration(ContainerBuilder $container)
+    {
+        $config = [
+            'router' => [
+                'default_router' => [
+                    'non_siteaccess_aware_routes' => [
+                        'ez_hybrid_platform_ui_dashboard_view_tab',
+                    ],
+                ],
+            ],
+        ];
+
+        $container->prependExtensionConfig('ezpublish', $config);
     }
 }

--- a/src/bundle/EzSystemsHybridPlatformUiBundle.php
+++ b/src/bundle/EzSystemsHybridPlatformUiBundle.php
@@ -3,6 +3,7 @@
 namespace EzSystems\HybridPlatformUiBundle;
 
 use EzSystems\HybridPlatformUi\Platform\AdminSiteAccessConfigurationFilter;
+use EzSystems\HybridPlatformUiBundle\DependencyInjection\Compiler\DashboardPass;
 use EzSystems\HybridPlatformUiBundle\DependencyInjection\Compiler\NavigationHubPass;
 use EzSystems\HybridPlatformUiBundle\DependencyInjection\Compiler\ToolbarsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -14,6 +15,7 @@ class EzSystemsHybridPlatformUiBundle extends Bundle
     {
         $container->addCompilerPass(new NavigationHubPass());
         $container->addCompilerPass(new ToolbarsPass());
+        $container->addCompilerPass(new DashboardPass());
 
         $eZExtension = $container->getExtension('ezpublish');
         $eZExtension->addSiteAccessConfigurationFilter(

--- a/src/bundle/Resources/config/dashboard.yml
+++ b/src/bundle/Resources/config/dashboard.yml
@@ -6,3 +6,49 @@ services:
 
     EzSystems\HybridPlatformUi\Dashboard\:
         resource: '../../../lib/Dashboard/*'
+
+    EzSystems\HybridPlatformUi\Dashboard\Section\MyContent:
+        calls:
+            - [setTemplate, ['EzSystemsHybridPlatformUiBundle:dashboard:my_content_section.html.twig']]
+            - [setParameter, ['identifier', 'my_content']]
+        tags:
+            - name: ezplatform.ui.dashboard.section
+              identifier: my_content
+              order: 1
+
+    EzSystems\HybridPlatformUi\Dashboard\Tab\MyDrafts:
+        calls:
+            - [setTemplate, ['EzSystemsHybridPlatformUiBundle:dashboard:my_drafts_tab.html.twig']]
+            - [setParameter, ['section_identifier', 'my_content']]
+            - [setParameter, ['identifier', 'my_drafts']]
+        tags:
+            - name: ezplatform.ui.dashboard.tab
+              section: my_content
+              identifier: my_drafts
+              order: 1
+
+    EzSystems\HybridPlatformUi\Dashboard\Tab\MyContent:
+        calls:
+            - [setTemplate, ['EzSystemsHybridPlatformUiBundle:dashboard:my_content_tab.html.twig']]
+            - [setParameter, ['section_identifier', 'my_content']]
+            - [setParameter, ['identifier', 'my_content']]
+        arguments:
+            $permissionResolver: '@=service("ezpublish.api.repository").getPermissionResolver()'
+        tags:
+            - name: ezplatform.ui.dashboard.tab
+              section: my_content
+              identifier: my_content
+              order: 10
+
+    EzSystems\HybridPlatformUi\Dashboard\Tab\MyMedia:
+        calls:
+            - [setTemplate, ['EzSystemsHybridPlatformUiBundle:dashboard:my_content_tab.html.twig']]
+            - [setParameter, ['section_identifier', 'my_content']]
+            - [setParameter, ['identifier', 'my_media']]
+        arguments:
+            $permissionResolver: '@=service("ezpublish.api.repository").getPermissionResolver()'
+        tags:
+            - name: ezplatform.ui.dashboard.tab
+              section: my_content
+              identifier: my_media
+              order: 20

--- a/src/bundle/Resources/config/dashboard.yml
+++ b/src/bundle/Resources/config/dashboard.yml
@@ -52,3 +52,34 @@ services:
               section: my_content
               identifier: my_media
               order: 20
+
+    EzSystems\HybridPlatformUi\Dashboard\Section\AllContent:
+        calls:
+            - [setTemplate, ['EzSystemsHybridPlatformUiBundle:dashboard:all_content_section.html.twig']]
+            - [setParameter, ['identifier', 'all_content']]
+        tags:
+            - name: ezplatform.ui.dashboard.section
+              identifier: all_content
+              order: 10
+
+    EzSystems\HybridPlatformUi\Dashboard\Tab\AllContent:
+        calls:
+            - [setTemplate, ['EzSystemsHybridPlatformUiBundle:dashboard:all_content_tab.html.twig']]
+            - [setParameter, ['section_identifier', 'all_content']]
+            - [setParameter, ['identifier', 'all_content']]
+        tags:
+            - name: ezplatform.ui.dashboard.tab
+              section: all_content
+              identifier: all_content
+              order: 1
+
+    EzSystems\HybridPlatformUi\Dashboard\Tab\AllMedia:
+        calls:
+            - [setTemplate, ['EzSystemsHybridPlatformUiBundle:dashboard:all_content_tab.html.twig']]
+            - [setParameter, ['section_identifier', 'all_content']]
+            - [setParameter, ['identifier', 'all_media']]
+        tags:
+            - name: ezplatform.ui.dashboard.tab
+              section: all_content
+              identifier: all_media
+              order: 10

--- a/src/bundle/Resources/config/dashboard.yml
+++ b/src/bundle/Resources/config/dashboard.yml
@@ -1,0 +1,8 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    EzSystems\HybridPlatformUi\Dashboard\:
+        resource: '../../../lib/Dashboard/*'

--- a/src/bundle/Resources/config/navigationhub.yml
+++ b/src/bundle/Resources/config/navigationhub.yml
@@ -65,7 +65,7 @@ services:
         class: "%ezsystems.platformui.navigationhub.link.route.class%"
         arguments:
             - "@router"
-            - "admin_dashboard"
+            - "ez_hybrid_platform_ui_dashboard"
             - "Dashboard"
             - "admin"
         tags:

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -3,6 +3,11 @@ ez_hybrid_platform_ui_dashboard:
     defaults:
         _controller: EzSystemsHybridPlatformUiBundle:Dashboard:viewDashboard
     methods: [GET]
+ez_hybrid_platform_ui_dashboard_view_tab:
+    path: /dashboard/view/{sectionIdentifier}/{tabIdentifier}
+    defaults:
+        _controller: EzSystemsHybridPlatformUiBundle:Dashboard:viewTab
+    methods: [GET]
 ez_hybrid_platform_ui_version_draft_actions:
     path: /content/{contentId}/versions/drafts
     defaults:

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -19,12 +19,17 @@ services:
 
     EzSystems\HybridPlatformUi\:
         resource: '../../../lib/*'
-        exclude: '../../../lib/{Components,NavigationHub,Repository/Values,Http/Response}'
+        exclude: '../../../lib/{Dashboard,Components,NavigationHub,Repository/Values,Http/Response}'
 
     EzSystems\HybridPlatformUiBundle\Controller\:
         resource: '../../Controller'
         public: true
         tags: ['controller.service_arguments']
+
+    EzSystems\HybridPlatformUiBundle\Controller\DashboardController:
+        public: true
+        arguments:
+            $dashboard: '@EzSystems\HybridPlatformUi\Dashboard\Dashboard'
 
     EzSystems\HybridPlatformUi\EventSubscriber\:
         resource: '../../../lib/EventSubscriber'

--- a/src/bundle/Resources/public/css/modules/table-data.css
+++ b/src/bundle/Resources/public/css/modules/table-data.css
@@ -40,3 +40,8 @@
     /* so that, if there's only one td (Role pages), it's left aligned */
     text-align: left;
 }
+
+.ez-dashboard-tabs .ez-table-data thead tr {
+    background: var(--ez-color-ground-secondary-medium);
+    color: var(--ez-color-text-base-inverted);
+}

--- a/src/bundle/Resources/public/css/modules/tabs.css
+++ b/src/bundle/Resources/public/css/modules/tabs.css
@@ -27,3 +27,26 @@
     background: var(--ez-color-ground-base);
     font-weight: bold;
 }
+
+.ez-dashboard-tabs {
+    background: var(--ez-color-ground-base);
+    width: 90%;
+    margin: 0 auto;
+    padding: 1em;
+    border-radius: 5px;
+}
+
+.ez-dashboard-tabs .ez-tabs-label.is-tab-selected a {
+    color: var(--ez-color-text-base-inverted);
+    background: var(--ez-color-ground-secondary);
+}
+
+.ez-dashboard-tabs h3 {
+    margin-top: 0;
+}
+
+.ez-dashboard-tabs .ez-tabs-list {
+    background: var(--ez-color-ground-base);
+    border-bottom: 5px solid var(--ez-color-ground-secondary);
+    margin-bottom: 1em;
+}

--- a/src/bundle/Resources/public/css/variables.css
+++ b/src/bundle/Resources/public/css/variables.css
@@ -35,6 +35,8 @@
     --ez-color-ground-base: #fafafa;
     --ez-color-ground-base-light: #f3f3f3;
     --ez-color-ground-base-medium: #e5e3e3;
+    --ez-color-ground-secondary: #445A64;
+    --ez-color-ground-secondary-medium: #62828F;
 
     /* notifications */
     --ez-color-positive-feedback: #00825c;

--- a/src/bundle/Resources/translations/messages.en.xlf
+++ b/src/bundle/Resources/translations/messages.en.xlf
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file date="2017-08-29T09:15:31Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="aac51e37a7b683e6d93b72179c44ee089827e450" resname="dashboard.button.edit">
+        <source>Edit</source>
+        <target state="new">Edit</target>
+        <note>key: dashboard.button.edit</note>
+        <jms:reference-file line="21">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/all_content_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="21">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/all_media_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="21">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_content_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="25">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_drafts_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="21">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_media_tab.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="8f2d000c044a9f04c457499e57f6fbbb8360e23f" resname="dashboard.tab.all_content.empty">
+        <source>No content items. Content items you create will appear here</source>
+        <target state="new">No content items. Content items you create will appear here</target>
+        <note>key: dashboard.tab.all_content.empty</note>
+        <jms:reference-file line="33">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/all_content_tab.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="50e7fa5609748dabc694245d5a54a77e9d5c7c1f" resname="dashboard.tab.all_media.empty">
+        <source>No content items. Media items you create will appear here</source>
+        <target state="new">No content items. Media items you create will appear here</target>
+        <note>key: dashboard.tab.all_media.empty</note>
+        <jms:reference-file line="33">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/all_media_tab.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="9c6f10545440752bc7bc2e8142cbea5d265403cd" resname="dashboard.tab.my_content.empty">
+        <source>No content items. Content items you create will appear here</source>
+        <target state="new">No content items. Content items you create will appear here</target>
+        <note>key: dashboard.tab.my_content.empty</note>
+        <jms:reference-file line="33">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_content_tab.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="cf10aced822b4dfb2cb519a82ed0adabaa4e480e" resname="dashboard.tab.my_drafts.empty">
+        <source>No content items. Draft items you create will appear here</source>
+        <target state="new">No content items. Draft items you create will appear here</target>
+        <note>key: dashboard.tab.my_drafts.empty</note>
+        <jms:reference-file line="37">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_drafts_tab.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="9ef83b3497fae569ba56b6a8ab96004f359ae918" resname="dashboard.tab.my_media.empty">
+        <source>No content items. Media items you create will appear here</source>
+        <target state="new">No content items. Media items you create will appear here</target>
+        <note>key: dashboard.tab.my_media.empty</note>
+        <jms:reference-file line="33">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_media_tab.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="e17a8999c9e44b7e8ea1ba0f5cff596ece264da5" resname="dashboard.table.content_type">
+        <source>Content Type</source>
+        <target state="new">Content Type</target>
+        <note>key: dashboard.table.content_type</note>
+        <jms:reference-file line="6">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/all_content_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/all_media_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_content_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_drafts_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="6">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_media_tab.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="3a857cc58c009830e22845ef1edbd43794206aed" resname="dashboard.table.last_saved">
+        <source>Last Saved</source>
+        <target state="new">Last Saved</target>
+        <note>key: dashboard.table.last_saved</note>
+        <jms:reference-file line="7">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/all_content_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/all_media_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_content_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="9">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_drafts_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="7">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_media_tab.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="0ccebfdea2e8be0bcae0f3cab3f3db5ef47d71c8" resname="dashboard.table.modified_language">
+        <source>Modified Language</source>
+        <target state="new">Modified Language</target>
+        <note>key: dashboard.table.modified_language</note>
+        <jms:reference-file line="7">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_drafts_tab.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="8ba6a26d5deb87771ede293eccde417dfafb8c67" resname="dashboard.table.name">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note>key: dashboard.table.name</note>
+        <jms:reference-file line="5">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/all_content_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/all_media_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_content_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_drafts_tab.html.twig</jms:reference-file>
+        <jms:reference-file line="5">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_media_tab.html.twig</jms:reference-file>
+      </trans-unit>
+      <trans-unit id="783d5adc52cea6b0cc80c2083158297f31a8d59d" resname="dashboard.table.version">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note>key: dashboard.table.version</note>
+        <jms:reference-file line="8">/../vendor/ezsystems/hybrid-platform-ui/src/bundle/Resources/views/dashboard/my_drafts_tab.html.twig</jms:reference-file>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/bundle/Resources/views/dashboard.html.twig
+++ b/src/bundle/Resources/views/dashboard.html.twig
@@ -1,3 +1,5 @@
 <ez-server-side-content>
-    <h1>Dashboard</h1>
+    {% for section in dashboard.getSections() %}
+        {{ section.render()|raw }}
+    {% endfor %}
 </ez-server-side-content>

--- a/src/bundle/Resources/views/dashboard/all_content_section.html.twig
+++ b/src/bundle/Resources/views/dashboard/all_content_section.html.twig
@@ -1,0 +1,26 @@
+<section class='ez-tabs ez-dashboard-tabs'>
+    <h3>{{ ('dashboard.section.' ~ identifier)|trans|desc('Everyone') }}</h3>
+
+    <ul class="ez-tabs-list">
+        {% for tab_name, tab in tabs %}
+            <li class="ez-tabs-label{% if loop.first %} is-tab-selected{% endif %}">
+                {% set display_name = tab_name|split('_')|join(' ')|capitalize %}
+                <a href="#ez-dashboard-{{ identifier }}-tab-{{ tab_name }}">{{ ('dashboard.tab.' ~ tab_name)|trans|desc(display_name) }}</a>
+            </li>
+        {% endfor %}
+    </ul>
+
+    {% for tab_name, tab in tabs %}
+        <ez-asynchronous-block class="ez-tabs-panel{% if loop.first %} is-tab-selected{% endif %}" id="ez-dashboard-{{ identifier }}-tab-{{ tab_name }}" url="{{ url('ez_hybrid_platform_ui_dashboard_view_tab', {
+            'sectionIdentifier': identifier,
+            'tabIdentifier': tab_name,
+        }) }}">
+            {% if loop.first %}
+                {{ render(controller('EzSystemsHybridPlatformUiBundle:Dashboard:viewTab', {
+                    'sectionIdentifier': identifier,
+                    'tabIdentifier': tab_name,
+                }))|raw }}
+            {% endif %}
+        </ez-asynchronous-block>
+    {% endfor %}
+</section>

--- a/src/bundle/Resources/views/dashboard/all_content_tab.html.twig
+++ b/src/bundle/Resources/views/dashboard/all_content_tab.html.twig
@@ -1,0 +1,34 @@
+{% if data|length %}
+    <table class="ez-table-data">
+        <thead>
+        <tr>
+            <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
+            <th>{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
+            <th>{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
+            <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for row in data %}
+            <tr>
+                <td><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
+                <td>{{ row.type }}</td>
+                <td>{{ row.modified|date('M d, Y h:iA') }}</td>
+                <td><a href="{{ url('ez_content_edit', {
+                    'contentId': row.contentId,
+                    'versionNo': row.version,
+                    'language': row.language
+                }) }}" class="ez-button">{{ 'dashboard.button.edit'|trans|desc('Edit') }}</a></td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% if pages_urls|length > 1 %}
+        <ez-pagination
+            current-page="{{ current_page }}"
+            pages-urls='{{ pages_urls|json_encode(constant('JSON_FORCE_OBJECT')) }}'
+        ></ez-pagination>
+    {% endif %}
+{% else %}
+    <p class="ez-table-empty">{{ 'dashboard.tab.all_content.empty'|trans|desc('No content items. Content items you create will appear here') }}</p>
+{% endif %}

--- a/src/bundle/Resources/views/dashboard/all_media_tab.html.twig
+++ b/src/bundle/Resources/views/dashboard/all_media_tab.html.twig
@@ -1,0 +1,34 @@
+{% if data|length %}
+    <table class="ez-table-data">
+        <thead>
+        <tr>
+            <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
+            <th>{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
+            <th>{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
+            <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for row in data %}
+            <tr>
+                <td><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
+                <td>{{ row.type }}</td>
+                <td>{{ row.modified|date('M d, Y h:iA') }}</td>
+                <td><a href="{{ url('ez_content_edit', {
+                        'contentId': row.contentId,
+                        'versionNo': row.version,
+                        'language': row.language
+                    }) }}" class="ez-button">{{ 'dashboard.button.edit'|trans|desc('Edit') }}</a></td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% if pages_urls|length > 1 %}
+        <ez-pagination
+                current-page="{{ current_page }}"
+                pages-urls='{{ pages_urls|json_encode(constant('JSON_FORCE_OBJECT')) }}'
+        ></ez-pagination>
+    {% endif %}
+{% else %}
+    <p class="ez-table-empty">{{ 'dashboard.tab.all_media.empty'|trans|desc('No content items. Media items you create will appear here') }}</p>
+{% endif %}

--- a/src/bundle/Resources/views/dashboard/my_content_section.html.twig
+++ b/src/bundle/Resources/views/dashboard/my_content_section.html.twig
@@ -1,0 +1,26 @@
+<section class='ez-tabs ez-dashboard-tabs'>
+    <h3>{{ ('dashboard.section.' ~ identifier)|trans|desc('Me') }}</h3>
+
+    <ul class="ez-tabs-list">
+        {% for tab_name, tab in tabs %}
+            <li class="ez-tabs-label{% if loop.first %} is-tab-selected{% endif %}">
+                {% set display_name = tab_name|split('_')|join(' ')|capitalize %}
+                <a href="#ez-dashboard-{{ identifier }}-tab-{{ tab_name }}">{{ ('dashboard.tab.' ~ tab_name)|trans|desc(display_name) }}</a>
+            </li>
+        {% endfor %}
+    </ul>
+
+    {% for tab_name, tab in tabs %}
+        <ez-asynchronous-block class="ez-tabs-panel{% if loop.first %} is-tab-selected{% endif %}" id="ez-dashboard-{{ identifier }}-tab-{{ tab_name }}" url="{{ url('ez_hybrid_platform_ui_dashboard_view_tab', {
+            'sectionIdentifier': identifier,
+            'tabIdentifier': tab_name,
+        }) }}">
+            {% if loop.first %}
+                {{ render(controller('EzSystemsHybridPlatformUiBundle:Dashboard:viewTab', {
+                    'sectionIdentifier': identifier,
+                    'tabIdentifier': tab_name,
+                }))|raw }}
+            {% endif %}
+        </ez-asynchronous-block>
+    {% endfor %}
+</section>

--- a/src/bundle/Resources/views/dashboard/my_content_tab.html.twig
+++ b/src/bundle/Resources/views/dashboard/my_content_tab.html.twig
@@ -1,0 +1,34 @@
+{% if data|length %}
+    <table class="ez-table-data">
+        <thead>
+        <tr>
+            <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
+            <th>{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
+            <th>{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
+            <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for row in data %}
+            <tr>
+                <td><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
+                <td>{{ row.type }}</td>
+                <td>{{ row.modified|date('M d, Y h:iA') }}</td>
+                <td><a href="{{ url('ez_content_edit', {
+                        'contentId': row.contentId,
+                        'versionNo': row.version,
+                        'language': row.language
+                    }) }}" class="ez-button">{{ 'dashboard.button.edit'|trans|desc('Edit') }}</a></td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% if pages_urls|length > 1 %}
+        <ez-pagination
+                current-page="{{ current_page }}"
+                pages-urls='{{ pages_urls|json_encode(constant('JSON_FORCE_OBJECT')) }}'
+        ></ez-pagination>
+    {% endif %}
+{% else %}
+    <p class="ez-table-empty">{{ 'dashboard.tab.my_content.empty'|trans|desc('No content items. Content items you create will appear here') }}</p>
+{% endif %}

--- a/src/bundle/Resources/views/dashboard/my_drafts_tab.html.twig
+++ b/src/bundle/Resources/views/dashboard/my_drafts_tab.html.twig
@@ -1,0 +1,38 @@
+{% if data|length %}
+    <table class="ez-table-data">
+        <thead>
+        <tr>
+            <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
+            <th>{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
+            <th>{{ 'dashboard.table.modified_language'|trans|desc('Modified Language') }}</th>
+            <th>{{ 'dashboard.table.version'|trans|desc('Version') }}</th>
+            <th>{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
+            <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for row in data %}
+            <tr>
+                <td>{{ row.name }}</td>
+                <td>{{ row.type }}</td>
+                <td>{{ row.language }}</td>
+                <td>{{ row.version }}</td>
+                <td>{{ row.modified|date('M d, Y h:iA') }}</td>
+                <td><a href="{{ url('ez_content_edit', {
+                    'contentId': row.contentId,
+                    'versionNo': row.version,
+                    'language': row.language
+                }) }}" class="ez-button">{{ 'dashboard.button.edit'|trans|desc('Edit') }}</a></td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% if pages_urls|length > 1 %}
+        <ez-pagination
+            current-page="{{ current_page }}"
+            pages-urls='{{ pages_urls|json_encode(constant('JSON_FORCE_OBJECT')) }}'
+        ></ez-pagination>
+    {% endif %}
+{% else %}
+    <p class="ez-table-empty">{{ 'dashboard.tab.my_drafts.empty'|trans|desc('No content items. Draft items you create will appear here') }}</p>
+{% endif %}

--- a/src/bundle/Resources/views/dashboard/my_media_tab.html.twig
+++ b/src/bundle/Resources/views/dashboard/my_media_tab.html.twig
@@ -1,0 +1,34 @@
+{% if data|length %}
+    <table class="ez-table-data">
+        <thead>
+        <tr>
+            <th>{{ 'dashboard.table.name'|trans|desc('Name') }}</th>
+            <th>{{ 'dashboard.table.content_type'|trans|desc('Content Type') }}</th>
+            <th>{{ 'dashboard.table.last_saved'|trans|desc('Last Saved') }}</th>
+            <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for row in data %}
+            <tr>
+                <td><a href="{{ url('_ez_content_view', { 'contentId': row.contentId }) }}">{{ row.name }}</a></td>
+                <td>{{ row.type }}</td>
+                <td>{{ row.modified|date('M d, Y h:iA') }}</td>
+                <td><a href="{{ url('ez_content_edit', {
+                        'contentId': row.contentId,
+                        'versionNo': row.version,
+                        'language': row.language
+                    }) }}" class="ez-button">{{ 'dashboard.button.edit'|trans|desc('Edit') }}</a></td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% if pages_urls|length > 1 %}
+        <ez-pagination
+                current-page="{{ current_page }}"
+                pages-urls='{{ pages_urls|json_encode(constant('JSON_FORCE_OBJECT')) }}'
+        ></ez-pagination>
+    {% endif %}
+{% else %}
+    <p class="ez-table-empty">{{ 'dashboard.tab.my_media.empty'|trans|desc('No content items. Media items you create will appear here') }}</p>
+{% endif %}

--- a/src/lib/Dashboard/Dashboard.php
+++ b/src/lib/Dashboard/Dashboard.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Dashboard;
+
+class Dashboard
+{
+    /** @var SectionInterface[] */
+    protected $sections = [];
+
+    /**
+     * @param string $identifier
+     *
+     * @return SectionInterface
+     */
+    public function getSection(string $identifier): SectionInterface
+    {
+        return $this->sections[$identifier];
+    }
+
+    /**
+     * @return SectionInterface[]
+     */
+    public function getSections(): array
+    {
+        return $this->sections;
+    }
+
+    /**
+     * @param string $identifier
+     * @param SectionInterface $section
+     */
+    public function setSection(string $identifier, SectionInterface $section)
+    {
+        $this->sections[$identifier] = $section;
+    }
+
+    /**
+     * @param array $sections
+     */
+    public function setSections(array $sections)
+    {
+        foreach ($sections as $identifier => $section) {
+            $this->setSection($identifier, $section);
+        }
+    }
+}

--- a/src/lib/Dashboard/PaginatedTab.php
+++ b/src/lib/Dashboard/PaginatedTab.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Dashboard;
+
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Templating\EngineInterface;
+
+abstract class PaginatedTab implements TabInterface
+{
+    /** @var EngineInterface */
+    protected $templating;
+
+    /** @var RouterInterface */
+    protected $router;
+
+    /** @var string */
+    protected $template;
+
+    /** @var array */
+    protected $parameters = [];
+
+    /**
+     * @param EngineInterface $templating
+     * @param RouterInterface $router
+     */
+    public function __construct(EngineInterface $templating, RouterInterface $router)
+    {
+        $this->templating = $templating;
+        $this->router = $router;
+    }
+
+    /**
+     * @param string $template
+     */
+    public function setTemplate(string $template)
+    {
+        $this->template = $template;
+    }
+
+    /**
+     * @param string $parameter
+     * @param mixed $value
+     */
+    public function setParameter(string $parameter, $value)
+    {
+        $this->parameters[$parameter] = $value;
+    }
+
+    public function setParameters(array $parameters)
+    {
+        foreach ($parameters as $identifier => $parameter) {
+            $this->setParameter($identifier, $parameter);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @param string $parameter
+     *
+     * @return mixed
+     */
+    public function getParameter(string $parameter)
+    {
+        return $this->parameters[$parameter];
+    }
+
+    /**
+     * @param int $current
+     * @param int $last
+     *
+     * @return array
+     */
+    protected function getPaginatorUrls(int $current, int $last): array
+    {
+        $urls = [1 => $this->getPageUrl(1)];
+        $urls[$last] = $this->getPageUrl($last);
+
+        $from = max(2, $current - 2);
+        $to = min($last - 1, $current + 2);
+
+        for ($i = $from; $i <= $to; ++$i) {
+            $urls[$i] = $this->getPageUrl($i);
+        }
+
+        return $urls;
+    }
+
+    /**
+     * @param int $page
+     *
+     * @return string
+     */
+    protected function getPageUrl(int $page): string
+    {
+        return $this->router->generate('ez_hybrid_platform_ui_dashboard_view_tab', [
+            'sectionIdentifier' => $this->getParameter('section_identifier'),
+            'tabIdentifier' => $this->getParameter('identifier'),
+            'page' => $page,
+        ]);
+    }
+
+    /**
+     * @param int $page
+     *
+     * @return string
+     */
+    public function render($page = 1): string
+    {
+        return $this->templating->render($this->template, $this->parameters);
+    }
+}

--- a/src/lib/Dashboard/Section/AllContent.php
+++ b/src/lib/Dashboard/Section/AllContent.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Dashboard\Section;
+
+use EzSystems\HybridPlatformUi\Dashboard\TabsSection;
+
+class AllContent extends TabsSection
+{
+}

--- a/src/lib/Dashboard/Section/MyContent.php
+++ b/src/lib/Dashboard/Section/MyContent.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Dashboard\Section;
+
+use EzSystems\HybridPlatformUi\Dashboard\TabsSection;
+
+class MyContent extends TabsSection
+{
+}

--- a/src/lib/Dashboard/SectionInterface.php
+++ b/src/lib/Dashboard/SectionInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Dashboard;
+
+interface SectionInterface
+{
+    /**
+     * @return string
+     */
+    public function render(): string;
+}

--- a/src/lib/Dashboard/Tab/AllContent.php
+++ b/src/lib/Dashboard/Tab/AllContent.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Dashboard\Tab;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchAdapter;
+use EzSystems\HybridPlatformUi\Dashboard\PaginatedTab;
+use Pagerfanta\Pagerfanta;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Templating\EngineInterface;
+
+class AllContent extends PaginatedTab
+{
+    /** @var ContentService */
+    protected $contentService;
+
+    /** @var ContentTypeService */
+    protected $contentTypeService;
+
+    /** @var SearchService */
+    protected $searchService;
+
+    /**
+     * @param EngineInterface $templating
+     * @param RouterInterface $router
+     * @param ContentService $contentService
+     * @param ContentTypeService $contentTypeService
+     * @param SearchService $searchService
+     */
+    public function __construct(
+        EngineInterface $templating,
+        RouterInterface $router,
+        ContentService $contentService,
+        ContentTypeService $contentTypeService,
+        SearchService $searchService
+    ) {
+        parent::__construct($templating, $router);
+
+        $this->contentService = $contentService;
+        $this->contentTypeService = $contentTypeService;
+        $this->searchService = $searchService;
+    }
+
+    /**
+     * @param Pagerfanta $pager
+     *
+     * @return array
+     */
+    private function getData(Pagerfanta $pager): array
+    {
+        $data = [];
+        foreach ($pager as $content) {
+            $contentInfo = $this->contentService->loadContentInfo($content->id);
+            $data[] = [
+                'contentId' => $content->id,
+                'name' => $contentInfo->name,
+                'language' => $contentInfo->mainLanguageCode,
+                'version' => $content->versionInfo->versionNo,
+                'type' => $this->contentTypeService->loadContentType($contentInfo->contentTypeId)->getName(),
+                'modified' => $content->versionInfo->modificationDate,
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param int $page
+     *
+     * @return string
+     */
+    public function render($page = 1): string
+    {
+        $query = new Query();
+        $query->filter = new Query\Criterion\Subtree('/1/2/');
+        $query->sortClauses = [new Query\SortClause\DateModified(Query::SORT_DESC)];
+
+        $pager = new Pagerfanta(
+            new ContentSearchAdapter($query, $this->searchService)
+        );
+        $pager->setMaxPerPage(10);
+        $pager->setCurrentPage($page);
+
+        $this->setParameter('current_page', $page);
+        $this->setParameter('data', $this->getData($pager));
+        $this->setParameter('pages_urls', $this->getPaginatorUrls(
+            $page,
+            $pager->getNbPages()
+        ));
+
+        return parent::render();
+    }
+}

--- a/src/lib/Dashboard/Tab/AllMedia.php
+++ b/src/lib/Dashboard/Tab/AllMedia.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Dashboard\Tab;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchAdapter;
+use EzSystems\HybridPlatformUi\Dashboard\PaginatedTab;
+use Pagerfanta\Pagerfanta;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Templating\EngineInterface;
+
+class AllMedia extends PaginatedTab
+{
+    /** @var ContentService */
+    protected $contentService;
+
+    /** @var ContentTypeService */
+    protected $contentTypeService;
+
+    /** @var SearchService */
+    protected $searchService;
+
+    /**
+     * @param EngineInterface $templating
+     * @param RouterInterface $router
+     * @param ContentService $contentService
+     * @param ContentTypeService $contentTypeService
+     * @param SearchService $searchService
+     */
+    public function __construct(
+        EngineInterface $templating,
+        RouterInterface $router,
+        ContentService $contentService,
+        ContentTypeService $contentTypeService,
+        SearchService $searchService
+    ) {
+        parent::__construct($templating, $router);
+
+        $this->contentService = $contentService;
+        $this->contentTypeService = $contentTypeService;
+        $this->searchService = $searchService;
+    }
+
+    /**
+     * @param Pagerfanta $pager
+     *
+     * @return array
+     */
+    private function getData(Pagerfanta $pager): array
+    {
+        $data = [];
+        foreach ($pager as $content) {
+            $contentInfo = $this->contentService->loadContentInfo($content->id);
+            $data[] = [
+                'contentId' => $content->id,
+                'name' => $contentInfo->name,
+                'language' => $contentInfo->mainLanguageCode,
+                'version' => $content->versionInfo->versionNo,
+                'type' => $this->contentTypeService->loadContentType($contentInfo->contentTypeId)->getName(),
+                'modified' => $content->versionInfo->modificationDate,
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param int $page
+     *
+     * @return string
+     */
+    public function render($page = 1): string
+    {
+        $query = new Query();
+        $query->filter = new Query\Criterion\Subtree('/1/43/');
+        $query->sortClauses = [new Query\SortClause\DateModified(Query::SORT_DESC)];
+
+        $pager = new Pagerfanta(
+            new ContentSearchAdapter($query, $this->searchService)
+        );
+        $pager->setMaxPerPage(10);
+        $pager->setCurrentPage($page);
+
+        $this->setParameter('current_page', $page);
+        $this->setParameter('data', $this->getData($pager));
+        $this->setParameter('pages_urls', $this->getPaginatorUrls(
+            $page,
+            $pager->getNbPages()
+        ));
+
+        return parent::render();
+    }
+}

--- a/src/lib/Dashboard/Tab/MyContent.php
+++ b/src/lib/Dashboard/Tab/MyContent.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Dashboard\Tab;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchAdapter;
+use EzSystems\HybridPlatformUi\Dashboard\PaginatedTab;
+use Pagerfanta\Pagerfanta;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Templating\EngineInterface;
+
+class MyContent extends PaginatedTab
+{
+    /** @var ContentService */
+    protected $contentService;
+
+    /** @var ContentTypeService */
+    protected $contentTypeService;
+
+    /** @var SearchService */
+    protected $searchService;
+
+    /** @var PermissionResolver */
+    protected $permissionResolver;
+
+    /**
+     * @param EngineInterface $templating
+     * @param RouterInterface $router
+     * @param ContentService $contentService
+     * @param ContentTypeService $contentTypeService
+     * @param SearchService $searchService
+     * @param PermissionResolver $permissionResolver
+     */
+    public function __construct(
+        EngineInterface $templating,
+        RouterInterface $router,
+        ContentService $contentService,
+        ContentTypeService $contentTypeService,
+        SearchService $searchService,
+        PermissionResolver $permissionResolver
+    ) {
+        parent::__construct($templating, $router);
+
+        $this->contentService = $contentService;
+        $this->contentTypeService = $contentTypeService;
+        $this->searchService = $searchService;
+        $this->permissionResolver = $permissionResolver;
+    }
+
+    /**
+     * @param Pagerfanta $pager
+     *
+     * @return array
+     */
+    private function getData(Pagerfanta $pager): array
+    {
+        $data = [];
+        foreach ($pager as $content) {
+            $contentInfo = $this->contentService->loadContentInfo($content->id);
+            $data[] = [
+                'contentId' => $content->id,
+                'name' => $contentInfo->name,
+                'language' => $contentInfo->mainLanguageCode,
+                'version' => $content->versionInfo->versionNo,
+                'type' => $this->contentTypeService->loadContentType($contentInfo->contentTypeId)->getName(),
+                'modified' => $content->versionInfo->modificationDate,
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param int $page
+     *
+     * @return string
+     */
+    public function render($page = 1): string
+    {
+        $query = new Query();
+        $query->filter = new Query\Criterion\LogicalAnd([
+            new Query\Criterion\Subtree('/1/2/'),
+            new Query\Criterion\UserMetadata(
+                Query\Criterion\UserMetadata::OWNER,
+                Operator::EQ,
+                $this->permissionResolver->getCurrentUserReference()->getUserId()
+            ),
+        ]);
+        $query->sortClauses = [new Query\SortClause\DateModified(Query::SORT_DESC)];
+
+        $pager = new Pagerfanta(
+            new ContentSearchAdapter($query, $this->searchService)
+        );
+        $pager->setMaxPerPage(10);
+        $pager->setCurrentPage($page);
+
+        $this->setParameter('current_page', $page);
+        $this->setParameter('data', $this->getData($pager));
+        $this->setParameter('pages_urls', $this->getPaginatorUrls(
+            $page,
+            $pager->getNbPages()
+        ));
+
+        return parent::render();
+    }
+}

--- a/src/lib/Dashboard/Tab/MyDrafts.php
+++ b/src/lib/Dashboard/Tab/MyDrafts.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Dashboard\Tab;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use EzSystems\HybridPlatformUi\Dashboard\PaginatedTab;
+use Pagerfanta\Adapter\ArrayAdapter;
+use Pagerfanta\Pagerfanta;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Templating\EngineInterface;
+
+class MyDrafts extends PaginatedTab
+{
+    /** @var ContentService */
+    protected $contentService;
+
+    /** @var ContentTypeService */
+    protected $contentTypeService;
+
+    /**
+     * MyDrafts constructor.
+     * @param EngineInterface $templating
+     * @param RouterInterface $router
+     * @param ContentService $contentService
+     * @param ContentTypeService $contentTypeService
+     */
+    public function __construct(
+        EngineInterface $templating,
+        RouterInterface $router,
+        ContentService $contentService,
+        ContentTypeService $contentTypeService
+    ) {
+        parent::__construct($templating, $router);
+
+        $this->contentService = $contentService;
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * @param Pagerfanta $pager
+     *
+     * @return array
+     */
+    private function getData(Pagerfanta $pager): array
+    {
+        $data = [];
+        foreach ($pager as $version) {
+            $contentInfo = $version->getContentInfo();
+            $data[] = [
+                'contentId' => $contentInfo->id,
+                'name' => $contentInfo->name,
+                'type' => $this->contentTypeService->loadContentType($contentInfo->contentTypeId)->getName(),
+                'language' => $version->initialLanguageCode,
+                'version' => $version->versionNo,
+                'modified' => $version->modificationDate,
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param int $page
+     *
+     * @return string
+     */
+    public function render($page = 1): string
+    {
+        $pager = new Pagerfanta(
+            new ArrayAdapter(
+                $this->contentService->loadContentDrafts()
+            )
+        );
+        $pager->setMaxPerPage(10);
+        $pager->setCurrentPage($page);
+
+        $this->setParameter('current_page', $page);
+        $this->setParameter('data', $this->getData($pager));
+        $this->setParameter('pages_urls', $this->getPaginatorUrls(
+            $page,
+            $pager->getNbPages()
+        ));
+
+        return parent::render();
+    }
+}

--- a/src/lib/Dashboard/Tab/MyMedia.php
+++ b/src/lib/Dashboard/Tab/MyMedia.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Dashboard\Tab;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchAdapter;
+use EzSystems\HybridPlatformUi\Dashboard\PaginatedTab;
+use Pagerfanta\Pagerfanta;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Templating\EngineInterface;
+
+class MyMedia extends PaginatedTab
+{
+    /** @var ContentService */
+    protected $contentService;
+
+    /** @var ContentTypeService */
+    protected $contentTypeService;
+
+    /** @var SearchService */
+    protected $searchService;
+
+    /** @var PermissionResolver */
+    protected $permissionResolver;
+
+    /**
+     * @param EngineInterface $templating
+     * @param RouterInterface $router
+     * @param ContentService $contentService
+     * @param ContentTypeService $contentTypeService
+     * @param SearchService $searchService
+     * @param PermissionResolver $permissionResolver
+     */
+    public function __construct(
+        EngineInterface $templating,
+        RouterInterface $router,
+        ContentService $contentService,
+        ContentTypeService $contentTypeService,
+        SearchService $searchService,
+        PermissionResolver $permissionResolver
+    ) {
+        parent::__construct($templating, $router);
+
+        $this->contentService = $contentService;
+        $this->contentTypeService = $contentTypeService;
+        $this->searchService = $searchService;
+        $this->permissionResolver = $permissionResolver;
+    }
+
+    /**
+     * @param Pagerfanta $pager
+     *
+     * @return array
+     */
+    private function getData(Pagerfanta $pager): array
+    {
+        $data = [];
+        foreach ($pager as $content) {
+            $contentInfo = $this->contentService->loadContentInfo($content->id);
+            $data[] = [
+                'contentId' => $content->id,
+                'name' => $contentInfo->name,
+                'language' => $contentInfo->mainLanguageCode,
+                'version' => $content->versionInfo->versionNo,
+                'type' => $this->contentTypeService->loadContentType($contentInfo->contentTypeId)->getName(),
+                'modified' => $content->versionInfo->modificationDate,
+            ];
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param int $page
+     *
+     * @return string
+     */
+    public function render($page = 1): string
+    {
+        $query = new Query();
+        $query->filter = new Query\Criterion\LogicalAnd([
+            new Query\Criterion\Subtree('/1/43/'),
+            new Query\Criterion\UserMetadata(
+                Query\Criterion\UserMetadata::OWNER,
+                Operator::EQ,
+                $this->permissionResolver->getCurrentUserReference()->getUserId()
+            ),
+        ]);
+        $query->sortClauses = [new Query\SortClause\DateModified(Query::SORT_DESC)];
+
+        $pager = new Pagerfanta(
+            new ContentSearchAdapter($query, $this->searchService)
+        );
+        $pager->setMaxPerPage(10);
+        $pager->setCurrentPage($page);
+
+        $this->setParameter('current_page', $page);
+        $this->setParameter('data', $this->getData($pager));
+        $this->setParameter('pages_urls', $this->getPaginatorUrls(
+            $page,
+            $pager->getNbPages()
+        ));
+
+        return parent::render();
+    }
+}

--- a/src/lib/Dashboard/TabInterface.php
+++ b/src/lib/Dashboard/TabInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Dashboard;
+
+interface TabInterface
+{
+    public function render(): string;
+}

--- a/src/lib/Dashboard/TabsSection.php
+++ b/src/lib/Dashboard/TabsSection.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace EzSystems\HybridPlatformUi\Dashboard;
+
+use Symfony\Component\Templating\EngineInterface;
+
+abstract class TabsSection implements SectionInterface
+{
+    /** @var EngineInterface */
+    protected $templating;
+
+    /** @var TabInterface[] */
+    protected $tabs = [];
+
+    /** @var string */
+    protected $template;
+
+    /** @var array */
+    protected $parameters = [];
+
+    /**
+     * @param EngineInterface $templating
+     */
+    public function __construct(EngineInterface $templating)
+    {
+        $this->templating = $templating;
+    }
+
+    /**
+     * @param string $identifier
+     *
+     * @return TabInterface
+     */
+    public function getTab(string $identifier): TabInterface
+    {
+        return $this->tabs[$identifier];
+    }
+
+    /**
+     * @return TabInterface[]
+     */
+    public function getTabs(): array
+    {
+        return $this->tabs;
+    }
+
+    /**
+     * @param string $identifier
+     *
+     * @param TabInterface $tab
+     */
+    public function setTab(string $identifier, TabInterface $tab)
+    {
+        $this->tabs[$identifier] = $tab;
+    }
+
+    /**
+     * @param TabInterface[] $tabs
+     */
+    public function setTabs(array $tabs)
+    {
+        foreach ($tabs as $identifier => $tab) {
+            $this->tabs[$identifier] = $tab;
+        }
+    }
+
+    /**
+     * @param string $template
+     */
+    public function setTemplate(string $template)
+    {
+        $this->template = $template;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTemplate(): string
+    {
+        return $this->template;
+    }
+
+    /**
+     * @param string $parameter
+     * @param $value
+     */
+    public function setParameter(string $parameter, $value)
+    {
+        $this->parameters[$parameter] = $value;
+    }
+
+    /**
+     * @param array $parameters
+     */
+    public function setParameters(array $parameters)
+    {
+        foreach ($parameters as $identifier => $parameter) {
+            $this->parameters[$identifier] = $parameter;
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @return string
+     */
+    public function render(): string
+    {
+        $this->setParameter('tabs', $this->getTabs());
+
+        return $this->templating->render($this->template, $this->parameters);
+    }
+}


### PR DESCRIPTION
**Jira ticket:** https://jira.ez.no/browse/EZP-27696
----

Depends on: https://github.com/ezsystems/hybrid-platform-ui/pull/104
----
### My Content: https://github.com/ezsystems/hybrid-platform-ui/pull/99/commits/d2bc3c2154b63ee4346b7c6586ee072aeacc8ac0
### All Content: https://github.com/ezsystems/hybrid-platform-ui/pull/99/commits/85d4b46e518129a023491d5daa3e189f6085231c

Implements:

- [EZP-27704](https://jira.ez.no/browse/EZP-27704) - As an Editor, I want to see a list of all content items which are created/owned by me in a widget labelled ‘Me’ split in 3 tabs - My drafts, My content, and My media
- [EZP-27705](https://jira.ez.no/browse/EZP-27705) - As an Editor, I want to see a list of all content items in the repository in a widget labelled ‘Everyone’ split in 2 tabs - Content and Media
- [EZP-27706](https://jira.ez.no/browse/EZP-27706) - As a Developer, I want to load content asynchronously for each tab
- [EZP-27707](https://jira.ez.no/browse/EZP-27707) - As an Editor, I want to have the option to edit a draft
- [EZP-27708](https://jira.ez.no/browse/EZP-27708) - As an Editor, I want to have the option to edit and view a published content item
- [EZP-27709](https://jira.ez.no/browse/EZP-27709) - As an Editor, I will see pagination option when the number of content items exceed the allowed limit of 10 in the table
- [EZP-27710](https://jira.ez.no/browse/EZP-27710) - Implement the new UI guidelines for Tabs and table