### PR TITLE
Fixed: make sure the discovery bar is visible when using _ez_content_view route

### DIFF
--- a/src/lib/App/ToolbarsConfigurator/RouteToolbarsConfigurator.php
+++ b/src/lib/App/ToolbarsConfigurator/RouteToolbarsConfigurator.php
@@ -19,6 +19,7 @@ class RouteToolbarsConfigurator implements ToolbarsConfigurator
 
     protected $routesConfiguration = [
         'ez_urlalias' => ['discovery' => 1],
+        '_ez_content_view' => ['discovery' => 1],
     ];
 
     public function __construct(RequestStack $requestStack)


### PR DESCRIPTION
This route is used when the user navigates with the Browse button or uses the
subitem list.