### PR TITLE
EZP-27586: Auto submit sort field/sort order and refresh subitem afterward

### DIFF
--- a/src/bundle/Form/Locations/Ordering.php
+++ b/src/bundle/Form/Locations/Ordering.php
@@ -10,7 +10,6 @@ use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationUpdateStruct;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\Translator;
@@ -31,7 +30,6 @@ class Ordering extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('Submit', SubmitType::class)
             ->add(
                 'sortField',
                 ChoiceType::class,

--- a/src/bundle/Resources/views/content/tabs/details.html.twig
+++ b/src/bundle/Resources/views/content/tabs/details.html.twig
@@ -78,7 +78,12 @@
     </tbody>
 </table>
 
-{{ form_start(orderingForm, {'action': path('ez_hybrid_platform_ui_location_sort_order', {'locationId': location.id, 'contentId': contentInfo.id})}) }}
+{{
+    form_start(orderingForm, {
+        'attr': {'class': 'ez-js-auto-submit'},
+        'action': path('ez_hybrid_platform_ui_location_sort_order', {'locationId': location.id, 'contentId': contentInfo.id})
+    })
+}}
 
 <div class="ez-list-toolbar">
     <h2 class="ez-list-toolbar-label">{{ 'locationview.details.sub.items.sorting.order'|trans()|desc('Sub-items sorting order') }}</h2>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27586

# Description

This patch and related PRs (https://github.com/ezsystems/hybrid-platform-ui-core-components/pull/39 and https://github.com/ezsystems/PlatformUIBundle/pull/894) brings the same behavior as in version 1 when changing the default sub-items sorting order ie setting the sort order is done automatically (no submit button) and after doing that, the sub-items are refreshed to take this change into account.

Screencast:

[![](https://img.youtube.com/vi/6QC2mygtMMk/0.jpg)](http://www.youtube.com/watch?v=6QC2mygtMMk "Click to play on Youtube.com")

## Tasks

* [x] Remove submit button
* [x] Configure the form to be auto submitted
* [x] Support auto submitted form (PR in https://github.com/ezsystems/hybrid-platform-ui-core-components/pull/39)
* [x] Add a `refresh` method to `<ez-subitem>` (https://github.com/ezsystems/PlatformUIBundle/pull/894)
* [x] Detect ordering change to trigger subitem refresh (https://github.com/ezsystems/hybrid-platform-ui-core-components/pull/39)

# Tests

unit test and manual tests