### PR TITLE
[Doc] Fix subtree link 4th param being array not int

### DIFF
--- a/docs/howto/add_navigation_hub_items.md
+++ b/docs/howto/add_navigation_hub_items.md
@@ -62,7 +62,7 @@ services:
             - '@router'
             - "Blog"
             - "content"
-            - 123
+            - {locationId: 123}
         tags:
             - {name: ezplatform.ui.link}
         public: false


### PR DESCRIPTION
Does anyone knows if the intention was to change implementation to actually take int here?

Or should it be array as this fixes doc for to allow for additional params in the future?